### PR TITLE
Add basic edge creation tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,9 +69,9 @@
              * This will then be read in MouseDroppableListener inside sprotty.
              */
             function dragstart(event, nodeType, width, height, text) {
+                // Position and id are set by the MouseDroppableListener
                 const nodeObject = {
                     type: "node:" + nodeType,
-                    id: nodeType + Math.random().toString(36).substring(7),
                     size: { width, height },
                     text,
                 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ import {
     withEditLabelFeature,
     zorderModule,
 } from "sprotty";
-import { toolsModules } from "./tools/tool-manager";
+import { toolsModules } from "./tools";
 import { commandsModule } from "./commands/commands";
 
 import "sprotty/css/sprotty.css";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
 import { Container, ContainerModule } from "inversify";
 import { SEdge as SEdgeSchema, SGraph as SGraphSchema, SLabel as SLabelSchema } from "sprotty-protocol";
 import {
+    ActionDispatcher,
     CenterGridSnapper,
     ConsoleLogger,
     LocalModelSource,
@@ -23,6 +24,7 @@ import {
     SLabelView,
     SRoutingHandle,
     SRoutingHandleView,
+    SetUIExtensionVisibilityAction,
     TYPES,
     boundsModule,
     configureModelElement,
@@ -49,6 +51,7 @@ import { commandsModule } from "./commands/commands";
 import "sprotty/css/sprotty.css";
 import "sprotty/css/edit-label.css";
 import "./page.css";
+import { ToolPaletteUI } from "./tools/toolPalette";
 
 // Setup the Dependency Injection Container.
 // This includes all used nodes, edges, listeners, etc. for sprotty.
@@ -180,7 +183,18 @@ const graph: SGraphSchema = {
 // Load the graph into the model source and display it inside the DOM.
 // Unless overwritten this will load the graph into the DOM element with the id "sprotty".
 const modelSource = container.get<LocalModelSource>(TYPES.ModelSource);
+const dispatcher = container.get<ActionDispatcher>(TYPES.IActionDispatcher);
 modelSource
     .setModel(graph)
-    .then(() => console.log("Sprotty model set."))
+    .then(() => {
+        console.log("Sprotty model set.");
+
+        // Show the tool palette after startup has completed.
+        dispatcher.dispatch(
+            SetUIExtensionVisibilityAction.create({
+                extensionId: ToolPaletteUI.ID,
+                visible: true,
+            }),
+        );
+    })
     .catch((reason) => console.error(reason));

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,18 @@ const graph: SGraphSchema = {
             id: "edge02",
             sourceId: "function01",
             targetId: "input01",
+            children: [
+                {
+                    type: "label",
+                    id: "label02",
+                    text: "",
+                    edgePlacement: {
+                        position: 0.5,
+                        side: "on",
+                        rotate: false,
+                    },
+                } as SLabelSchema,
+            ],
         } as SEdgeSchema,
     ],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
     ActionDispatcher,
     CenterGridSnapper,
     ConsoleLogger,
+    CreateElementCommand,
     LocalModelSource,
     LogLevel,
     SGraph,
@@ -27,6 +28,7 @@ import {
     SetUIExtensionVisibilityAction,
     TYPES,
     boundsModule,
+    configureCommand,
     configureModelElement,
     defaultModule,
     edgeEditModule,
@@ -73,6 +75,9 @@ const dataFlowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
     });
     configureModelElement(context, "routing-point", SRoutingHandle, SRoutingHandleView);
     configureModelElement(context, "volatile-routing-point", SRoutingHandle, SRoutingHandleView);
+
+    // For some reason the CreateElementAction and Command exist but in no sprotty module is the command registered, so we need to do this here.
+    configureCommand(context, CreateElementCommand);
 });
 
 // Load the above defined module with all the used modules from sprotty.

--- a/src/tools/commandPalette.ts
+++ b/src/tools/commandPalette.ts
@@ -6,6 +6,7 @@ import {
     SModelRoot,
     TYPES,
     commandPaletteModule,
+    EnableToolsAction,
 } from "sprotty";
 import { FitToScreenAction, Point } from "sprotty-protocol";
 import { LogHelloAction } from "../commands/log-hello";
@@ -13,6 +14,7 @@ import { LogHelloAction } from "../commands/log-hello";
 import "@vscode/codicons/dist/codicon.css";
 import "sprotty/css/command-palette.css";
 import "./commandPalette.css";
+import { EdgeCreationTool } from "./edgeCreationTool";
 
 /**
  * Provides possible actions for the command palette.
@@ -31,16 +33,11 @@ export class ServerCommandPaletteActionProvider implements ICommandPaletteAction
         );
 
         return [
+            new LabeledAction("Create new edge", [EnableToolsAction.create([EdgeCreationTool.ID])], "link"),
             new LabeledAction("Fit to Screen", [fitToScreenAction], "layout"),
             new LabeledAction("Export as SVG", [RequestExportSvgAction.create()], "export"),
-            // TODO: these are actions used for demonstration purposes including the LogHelloAction. These should be removed
+            // TODO: this action is only used for demonstration purposes including the LogHelloAction. This should be removed
             new LabeledAction("Log Hello World", [LogHelloAction.create("from command palette hello")], "symbol-event"),
-            new LabeledAction("Log Test", [LogHelloAction.create("from command palette test")], "zoom-in"),
-            new LabeledAction(
-                "Log lorem ipsum",
-                [LogHelloAction.create("from command palette lorem ipsum")],
-                "type-hierarchy-sub",
-            ),
         ];
     }
 }

--- a/src/tools/edgeCreationTool.ts
+++ b/src/tools/edgeCreationTool.ts
@@ -6,12 +6,10 @@ import {
     Tool,
     SModelElement,
     isConnectable,
-    TYPES,
-    LocalModelSource,
     SEdge,
     EnableDefaultToolsAction,
 } from "sprotty";
-import { Action, SEdge as SEdgeSchema, SLabel as SLabelSchema } from "sprotty-protocol";
+import { Action, CreateElementAction, SEdge as SEdgeSchema, SLabel as SLabelSchema } from "sprotty-protocol";
 import { EDITOR_TYPES, constructorInject, generateRandomSprottyId } from "../utils";
 
 @injectable()
@@ -19,10 +17,7 @@ export class EdgeCreationToolMouseListener extends MouseListener {
     private source?: SModelElement;
     private target?: SModelElement;
 
-    constructor(
-        @constructorInject(TYPES.ModelSource) protected modelSource: LocalModelSource,
-        private edgeType: string = "edge:arrow",
-    ) {
+    constructor(private edgeType: string = "edge:arrow") {
         super();
     }
 
@@ -70,10 +65,15 @@ export class EdgeCreationToolMouseListener extends MouseListener {
                     } as SLabelSchema,
                 ],
             } as SEdgeSchema;
-            this.modelSource.addElements([edge]);
 
-            // Disables the EdgeCreationTool and only enables the default tools
-            return [EnableDefaultToolsAction.create()];
+            return [
+                // Disables the EdgeCreationTool and only enables the default tools
+                EnableDefaultToolsAction.create(),
+                // Create the new edge
+                CreateElementAction.create(edge, {
+                    containerId: this.source.root.id,
+                }),
+            ];
         }
         return [];
     }

--- a/src/tools/edgeCreationTool.ts
+++ b/src/tools/edgeCreationTool.ts
@@ -1,0 +1,110 @@
+import { ContainerModule, injectable } from "inversify";
+import {
+    AnchorComputerRegistry,
+    MouseListener,
+    MouseTool,
+    Tool,
+    SModelElement,
+    isConnectable,
+    TYPES,
+    LocalModelSource,
+    SEdge,
+    EnableDefaultToolsAction,
+} from "sprotty";
+import { Action, SEdge as SEdgeSchema } from "sprotty-protocol";
+import { EDITOR_TYPES, constructorInject, generateRandomSprottyId } from "../utils";
+
+export class EdgeCreationToolMouseListener extends MouseListener {
+    private source?: SModelElement;
+    private target?: SModelElement;
+
+    constructor(protected modelSource: LocalModelSource, private edgeType: string = "edge:arrow") {
+        super();
+    }
+
+    override mouseDown(target: SModelElement, _event: MouseEvent): Action[] {
+        // First click selects the source (if valid source element)
+        // Second click selects the target and creates the edge (if valid target element)
+        if (this.source === undefined) {
+            return this.sourceClick(target);
+        } else {
+            return this.targetClick(target);
+        }
+    }
+
+    private sourceClick(element: SModelElement): Action[] {
+        if (this.canConnect(element, "source")) {
+            this.source = element;
+        }
+        return [];
+    }
+
+    private targetClick(element: SModelElement): Action[] {
+        if (this.source && this.source.id !== element.id && this.canConnect(element, "target")) {
+            // Add edge to diagram
+            this.target = element;
+            const edge = {
+                type: this.edgeType,
+                id: generateRandomSprottyId(),
+                sourceId: this.source.id,
+                targetId: this.target.id,
+            } as SEdgeSchema;
+            this.modelSource.addElements([edge]);
+
+            // Disables the EdgeCreationTool and only enables the default tools
+            return [EnableDefaultToolsAction.create()];
+        }
+        return [];
+    }
+
+    private canConnect(element: SModelElement, type: "source" | "target"): boolean {
+        if (type === "target" && element.id === this.source?.id) {
+            // Cannot connect to itself
+            return false;
+        }
+
+        // Construct pseudo edge to check if it can be connected
+        const edge = new SEdge();
+        edge.type = "edge:arrow";
+        if (this.source) edge.sourceId = this.source.id;
+        if (this.target) edge.targetId = this.target.id;
+
+        return isConnectable(element) && element.canConnect(edge, type);
+    }
+}
+
+@injectable()
+export class EdgeCreationTool implements Tool {
+    static ID = "edge-creation-tool";
+
+    protected edgeCreationToolMouseListener: EdgeCreationToolMouseListener;
+
+    constructor(
+        @constructorInject(AnchorComputerRegistry) protected anchorRegistry: AnchorComputerRegistry,
+        @constructorInject(MouseTool) protected mouseTool: MouseTool,
+        @constructorInject(TYPES.ModelSource) protected modelSource: LocalModelSource,
+    ) {
+        this.edgeCreationToolMouseListener = new EdgeCreationToolMouseListener(this.modelSource);
+    }
+
+    get id(): string {
+        return EdgeCreationTool.ID;
+    }
+
+    enable(): void {
+        this.edgeCreationToolMouseListener = new EdgeCreationToolMouseListener(this.modelSource);
+        this.mouseTool.register(this.edgeCreationToolMouseListener);
+        console.log("EdgeCreationTool.enable()");
+    }
+
+    disable(): void {
+        this.mouseTool.deregister(this.edgeCreationToolMouseListener);
+        console.log("EdgeCreationTool.disable()");
+    }
+}
+
+export const edgeCreationTool = new ContainerModule((bind) => {
+    bind(EdgeCreationToolMouseListener).toSelf().inSingletonScope();
+    bind(EdgeCreationTool).toSelf().inSingletonScope();
+    bind(EDITOR_TYPES.ITool).toService(EdgeCreationTool);
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,18 @@
+import { commandPaletteModules } from "./commandPalette";
+import { deleteKeyDeleteTool } from "./deleteKeyTool";
+import { edgeCreationTool } from "./edgeCreationTool";
+import { mouseDroppableTool } from "./mouseDroppableListener";
+import { toolManager } from "./tool-manager";
+import { toolPaletteModule } from "./toolPalette";
+
+// Exports all the tool related inversify modules.
+// This includes the configuration for the sprotty tool manager and all implemented tools.
+
+export const toolsModules = [
+    toolManager,
+    ...commandPaletteModules,
+    edgeCreationTool,
+    deleteKeyDeleteTool,
+    mouseDroppableTool,
+    toolPaletteModule,
+];

--- a/src/tools/mouseDroppableListener.ts
+++ b/src/tools/mouseDroppableListener.ts
@@ -1,6 +1,6 @@
 import { ContainerModule, injectable } from "inversify";
 import { MouseListener, TYPES, LocalModelSource, Tool, MouseTool } from "sprotty";
-import { SNode as SNodeSchema } from "sprotty-protocol";
+import { CreateElementAction, SNode as SNodeSchema } from "sprotty-protocol";
 import { SModelElement, Action } from "sprotty-protocol";
 import { EDITOR_TYPES, constructorInject, generateRandomSprottyId } from "../utils";
 
@@ -32,30 +32,32 @@ class MouseDroppableListener extends MouseListener {
             return [];
         }
 
-        this.modelSource.getViewport().then((viewport) => {
-            nodeData.id = generateRandomSprottyId();
-            if (!nodeData.size) {
-                // Default sizes for nodes that don't have a size set.
-                nodeData.size = {
-                    width: 10,
-                    height: 10,
+        return [
+            this.modelSource.getViewport().then((viewport) => {
+                nodeData.id = generateRandomSprottyId();
+                if (!nodeData.size) {
+                    // Default sizes for nodes that don't have a size set.
+                    nodeData.size = {
+                        width: 10,
+                        height: 10,
+                    };
+                }
+
+                // Adjust the position of the node so that it is centered on the cursor.
+                const adjust = (offset: number, size: number) => {
+                    return offset / viewport.zoom - size / 2;
                 };
-            }
+                nodeData.position = {
+                    x: viewport.scroll.x + adjust(event.offsetX, nodeData.size.width),
+                    y: viewport.scroll.y + adjust(event.offsetY, nodeData.size.height),
+                };
 
-            // Adjust the position of the node so that it is centered on the cursor.
-            const adjust = (offset: number, size: number) => {
-                return offset / viewport.zoom - size / 2;
-            };
-            nodeData.position = {
-                x: viewport.scroll.x + adjust(event.offsetX, nodeData.size.width),
-                y: viewport.scroll.y + adjust(event.offsetY, nodeData.size.height),
-            };
-
-            // Add the node to the diagram.
-            this.modelSource.addElements([nodeData]);
-        });
-
-        return [];
+                // Add the node to the diagram.
+                return CreateElementAction.create(nodeData, {
+                    containerId: this.modelSource.model.id,
+                });
+            }),
+        ];
     }
 }
 

--- a/src/tools/mouseDroppableListener.ts
+++ b/src/tools/mouseDroppableListener.ts
@@ -2,7 +2,7 @@ import { ContainerModule, injectable } from "inversify";
 import { MouseListener, TYPES, LocalModelSource, Tool, MouseTool } from "sprotty";
 import { SNode as SNodeSchema } from "sprotty-protocol";
 import { SModelElement, Action } from "sprotty-protocol";
-import { EDITOR_TYPES, constructorInject } from "../utils";
+import { EDITOR_TYPES, constructorInject, generateRandomSprottyId } from "../utils";
 
 /**
  * When dragging a node from the new element row from the top of the page to
@@ -33,6 +33,7 @@ class MouseDroppableListener extends MouseListener {
         }
 
         this.modelSource.getViewport().then((viewport) => {
+            nodeData.id = generateRandomSprottyId();
             if (!nodeData.size) {
                 // Default sizes for nodes that don't have a size set.
                 nodeData.size = {

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -1,11 +1,6 @@
 import { ContainerModule, injectable, multiInject, optional, postConstruct } from "inversify";
 import { ToolManager, Tool, TYPES } from "sprotty";
-import { commandPaletteModules } from "./commandPalette";
-import { deleteKeyDeleteTool } from "./deleteKeyTool";
 import { EDITOR_TYPES } from "../utils";
-import { mouseDroppableTool } from "./mouseDroppableListener";
-import { edgeCreationTool } from "./edgeCreationTool";
-import { toolPaletteModule } from "./toolPalette";
 
 /**
  * A tool manager that gets all our custom tools using dependency injection and registers them
@@ -26,12 +21,3 @@ export const toolManager = new ContainerModule((bind, _unbind, _isBound, rebind)
     bind(DFDToolManager).toSelf().inSingletonScope();
     rebind(TYPES.IToolManager).toService(DFDToolManager);
 });
-
-export const toolsModules = [
-    toolManager,
-    ...commandPaletteModules,
-    edgeCreationTool,
-    deleteKeyDeleteTool,
-    mouseDroppableTool,
-    toolPaletteModule,
-];

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -5,6 +5,7 @@ import { deleteKeyDeleteTool } from "./deleteKeyTool";
 import { EDITOR_TYPES } from "../utils";
 import { mouseDroppableTool } from "./mouseDroppableListener";
 import { edgeCreationTool } from "./edgeCreationTool";
+import { toolPaletteModule } from "./toolPalette";
 
 /**
  * A tool manager that gets all our custom tools using dependency injection and registers them
@@ -32,4 +33,5 @@ export const toolsModules = [
     edgeCreationTool,
     deleteKeyDeleteTool,
     mouseDroppableTool,
+    toolPaletteModule,
 ];

--- a/src/tools/tool-manager.ts
+++ b/src/tools/tool-manager.ts
@@ -4,6 +4,7 @@ import { commandPaletteModules } from "./commandPalette";
 import { deleteKeyDeleteTool } from "./deleteKeyTool";
 import { EDITOR_TYPES } from "../utils";
 import { mouseDroppableTool } from "./mouseDroppableListener";
+import { edgeCreationTool } from "./edgeCreationTool";
 
 /**
  * A tool manager that gets all our custom tools using dependency injection and registers them
@@ -25,4 +26,10 @@ export const toolManager = new ContainerModule((bind, _unbind, _isBound, rebind)
     rebind(TYPES.IToolManager).toService(DFDToolManager);
 });
 
-export const toolsModules = [toolManager, ...commandPaletteModules, deleteKeyDeleteTool, mouseDroppableTool];
+export const toolsModules = [
+    toolManager,
+    ...commandPaletteModules,
+    edgeCreationTool,
+    deleteKeyDeleteTool,
+    mouseDroppableTool,
+];

--- a/src/tools/toolPalette.css
+++ b/src/tools/toolPalette.css
@@ -1,0 +1,25 @@
+.tool-palette {
+    position: absolute;
+    right: 40px;
+    user-select: none;
+    background-color: #eee;
+    border-radius: 10px;
+    padding: 5px;
+    margin-top: 40px;
+}
+
+.tool-palette .tool {
+    width: 32px;
+    height: 32px;
+    padding: 2px;
+    border-radius: 5px;
+}
+
+.tool-palette .tool:hover {
+    cursor: pointer;
+    background-color: #ccc;
+}
+
+.tool-palette .tool.active {
+    background-color: #bbb;
+}

--- a/src/tools/toolPalette.css
+++ b/src/tools/toolPalette.css
@@ -1,11 +1,11 @@
 .tool-palette {
     position: absolute;
+    margin-top: 40px;
     right: 40px;
     user-select: none;
     background-color: #eee;
     border-radius: 10px;
     padding: 5px;
-    margin-top: 40px;
 }
 
 .tool-palette .tool {

--- a/src/tools/toolPalette.ts
+++ b/src/tools/toolPalette.ts
@@ -1,0 +1,90 @@
+import { ContainerModule, injectable } from "inversify";
+import {
+    AbstractUIExtension,
+    EnableDefaultToolsAction,
+    EnableToolsAction,
+    IActionDispatcher,
+    IActionHandler,
+    ICommand,
+    TYPES,
+    configureActionHandler,
+} from "sprotty";
+import { Action } from "sprotty-protocol";
+
+import "./toolPalette.css";
+import { constructorInject } from "../utils";
+import { EdgeCreationTool } from "./edgeCreationTool";
+
+@injectable()
+export class ToolPaletteUI extends AbstractUIExtension implements IActionHandler {
+    static readonly ID = "tool-palette";
+
+    constructor(@constructorInject(TYPES.IActionDispatcher) protected readonly actionDispatcher: IActionDispatcher) {
+        super();
+    }
+
+    id(): string {
+        return ToolPaletteUI.ID;
+    }
+
+    containerClass(): string {
+        return "tool-palette";
+    }
+
+    protected initializeContents(containerElement: HTMLElement): void {
+        const arrowEdgeElement = document.createElement("div");
+        arrowEdgeElement.classList.add("tool");
+        arrowEdgeElement.innerHTML = `
+        <svg width="32" height="32">
+
+        <defs>
+            <marker id="arrowhead" markerWidth="10" markerHeight="7"
+                    refX="0" refY="2" orient="auto">
+                <polygon points="0 0, 4 2, 0 4" />
+            </marker>
+        </defs>
+
+        <line x1="10%" y1="10%" x2="75%" y2="75%"
+                stroke="black" stroke-width="2"
+                marker-end="url(#arrowhead)" />
+        </svg>
+        `;
+
+        arrowEdgeElement.addEventListener("click", () => {
+            if (arrowEdgeElement.classList.contains("active")) {
+                this.actionDispatcher.dispatch(EnableDefaultToolsAction.create());
+            } else {
+                arrowEdgeElement.classList.toggle("active");
+                this.enableEdgeCreationTool();
+            }
+        });
+        containerElement.appendChild(arrowEdgeElement);
+        containerElement.classList.add("tool-palette");
+    }
+
+    private enableEdgeCreationTool(): void {
+        this.actionDispatcher.dispatch(EnableToolsAction.create([EdgeCreationTool.ID]));
+    }
+
+    handle(action: Action): void | Action | ICommand {
+        if (action.kind === EnableDefaultToolsAction.KIND) {
+            // Recursively remove the active class from all tools
+            const removeActiveClass = (element: HTMLElement) => {
+                element.classList.remove("active");
+                element.childNodes.forEach((child) => {
+                    if (child instanceof HTMLElement) {
+                        removeActiveClass(child);
+                    }
+                });
+            };
+            removeActiveClass(this.containerElement);
+        }
+    }
+}
+
+export const toolPaletteModule = new ContainerModule((bind, unbind, isBound, rebind) => {
+    const context = { bind, unbind, isBound, rebind };
+    bind(ToolPaletteUI).toSelf().inSingletonScope();
+    bind(TYPES.IUIExtension).toService(ToolPaletteUI);
+    configureActionHandler(context, EnableDefaultToolsAction.KIND, ToolPaletteUI);
+});

--- a/src/tools/toolPalette.ts
+++ b/src/tools/toolPalette.ts
@@ -10,11 +10,15 @@ import {
     configureActionHandler,
 } from "sprotty";
 import { Action } from "sprotty-protocol";
-
-import "./toolPalette.css";
 import { constructorInject } from "../utils";
 import { EdgeCreationTool } from "./edgeCreationTool";
 
+import "./toolPalette.css";
+
+/**
+ * UI extension that adds a tool palette to the diagram in the upper right.
+ * Currently this only allows activating the CreateEdgeTool.
+ */
 @injectable()
 export class ToolPaletteUI extends AbstractUIExtension implements IActionHandler {
     static readonly ID = "tool-palette";
@@ -52,7 +56,8 @@ export class ToolPaletteUI extends AbstractUIExtension implements IActionHandler
 
         arrowEdgeElement.addEventListener("click", () => {
             if (arrowEdgeElement.classList.contains("active")) {
-                this.actionDispatcher.dispatch(EnableDefaultToolsAction.create());
+                // Already activated => disable the tool
+                this.disableEdgeCreationTool();
             } else {
                 arrowEdgeElement.classList.toggle("active");
                 this.enableEdgeCreationTool();
@@ -66,18 +71,18 @@ export class ToolPaletteUI extends AbstractUIExtension implements IActionHandler
         this.actionDispatcher.dispatch(EnableToolsAction.create([EdgeCreationTool.ID]));
     }
 
+    private disableEdgeCreationTool(): void {
+        this.actionDispatcher.dispatch(EnableDefaultToolsAction.create());
+    }
+
     handle(action: Action): void | Action | ICommand {
+        // Unsets all active classes of the tool icons when all non-default tools are disabled
         if (action.kind === EnableDefaultToolsAction.KIND) {
-            // Recursively remove the active class from all tools
-            const removeActiveClass = (element: HTMLElement) => {
-                element.classList.remove("active");
-                element.childNodes.forEach((child) => {
-                    if (child instanceof HTMLElement) {
-                        removeActiveClass(child);
-                    }
-                });
-            };
-            removeActiveClass(this.containerElement);
+            this.containerElement.childNodes.forEach((node) => {
+                if (node instanceof HTMLElement) {
+                    node.classList.remove("active");
+                }
+            });
         }
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,3 +25,7 @@ export function constructorInject(
         inject(identifier)(target, targetKey!, index);
     };
 }
+
+export function generateRandomSprottyId(): string {
+    return Math.random().toString(36).substring(7);
+}

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -111,7 +111,7 @@ export class ArrowEdgeView extends PolylineEdgeViewWithGapsOnIntersections {
             <path
                 class-sprotty-edge={true}
                 class-arrow={true}
-                d="M 1,0 L 10,-4 L 10,4 Z"
+                d="M 0.5,0 L 10,-4 L 10,4 Z"
                 transform={`rotate(${toDegrees(angleOfPoint({ x: p1.x - p2.x, y: p1.y - p2.y }))} ${p2.x} ${
                     p2.y
                 }) translate(${p2.x} ${p2.y})`}


### PR DESCRIPTION
Adds a rudimentary edge creation tool:

https://github.com/PalladioSimulator/Palladio-Supporting-DataFlowConfidentiality-WebBasedEditor/assets/30466471/c059f879-296f-40e6-aef9-54942ae23a16

In the future dragging and previewing of the edge should be supported, this is just a basic usable implementation.