### PR TITLE
Add commands to load and save diagram as json file

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -2,6 +2,7 @@ import { ContainerModule } from "inversify";
 import { configureCommand } from "sprotty";
 import { LogHelloCommand } from "./log-hello";
 import { SaveDiagramCommand } from "./save";
+import { LoadDiagramCommand } from "./load";
 
 // Bundles all defined commands into a inversify module that can be loaded to make
 // all commands available to sprotty.
@@ -10,4 +11,5 @@ export const commandsModule = new ContainerModule((bind, unbind, isBound, rebind
     const context = { bind, unbind, isBound, rebind };
     configureCommand(context, LogHelloCommand);
     configureCommand(context, SaveDiagramCommand);
+    configureCommand(context, LoadDiagramCommand);
 });

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -1,6 +1,7 @@
 import { ContainerModule } from "inversify";
 import { configureCommand } from "sprotty";
 import { LogHelloCommand } from "./log-hello";
+import { SaveDiagramCommand } from "./save";
 
 // Bundles all defined commands into a inversify module that can be loaded to make
 // all commands available to sprotty.
@@ -8,4 +9,5 @@ import { LogHelloCommand } from "./log-hello";
 export const commandsModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     const context = { bind, unbind, isBound, rebind };
     configureCommand(context, LogHelloCommand);
+    configureCommand(context, SaveDiagramCommand);
 });

--- a/src/commands/load.ts
+++ b/src/commands/load.ts
@@ -1,0 +1,89 @@
+import { inject } from "inversify";
+import { Command, CommandExecutionContext, ILogger, LocalModelSource, NullLogger, SModelRoot, TYPES } from "sprotty";
+import { Action } from "sprotty-protocol";
+
+export interface LoadDiagramAction extends Action {
+    kind: typeof LoadDiagramAction.KIND;
+}
+export namespace LoadDiagramAction {
+    export const KIND = "load-diagram";
+
+    export function create(): LoadDiagramAction {
+        return {
+            kind: KIND,
+        };
+    }
+}
+
+export class LoadDiagramCommand extends Command {
+    static readonly KIND = LoadDiagramAction.KIND;
+    @inject(TYPES.ModelSource)
+    private modelSource: LocalModelSource = new LocalModelSource();
+    @inject(TYPES.ILogger)
+    private logger: ILogger = new NullLogger();
+
+    constructor() {
+        super();
+    }
+
+    execute(context: CommandExecutionContext): SModelRoot {
+        // Open a file picker dialog.
+        // The cleaner way to do this would be showOpenFilePicker(),
+        // but safari and firefox don't support it at the time of writing this code:
+        // https://developer.mozilla.org/en-US/docs/web/api/window/showOpenFilePicker#browser_compatibility
+        const input = document.createElement("input");
+        input.type = "file";
+        input.accept = ".json";
+        const fileLoadPromise = new Promise((resolve, reject) => {
+            input.onchange = () => {
+                if (input.files && input.files.length > 0) {
+                    const file = input.files[0];
+                    const reader = new FileReader();
+                    reader.onload = () => {
+                        const json = reader.result as string;
+                        const model = JSON.parse(json);
+                        resolve(model);
+                    };
+                    reader.onerror = () => {
+                        reject(reader.error);
+                    };
+                    reader.readAsText(file);
+                } else {
+                    reject("No file selected");
+                }
+            };
+        });
+        input.click();
+
+        fileLoadPromise
+            .then((model: any) => {
+                // TODO: document, move to dedicated class method
+                const removeFeatures = (model: any) => {
+                    delete model.features;
+                    if (model.children) {
+                        model.children.forEach((child: any) => removeFeatures(child));
+                    }
+                };
+                removeFeatures(model);
+
+                return this.modelSource.setModel(model);
+            })
+            .then(() => {
+                this.logger.info(this, "Model loaded successfully");
+            })
+            .catch((error) => {
+                this.logger.error(this, "Error loading model", error);
+            });
+
+        return context.root;
+    }
+
+    // TODO: undo and redo implementation
+    undo(context: CommandExecutionContext): SModelRoot {
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): SModelRoot {
+        return context.root;
+    }
+}

--- a/src/commands/load.ts
+++ b/src/commands/load.ts
@@ -1,6 +1,15 @@
 import { inject } from "inversify";
-import { Command, CommandExecutionContext, ILogger, LocalModelSource, NullLogger, SModelRoot, TYPES } from "sprotty";
-import { Action } from "sprotty-protocol";
+import {
+    Command,
+    CommandExecutionContext,
+    EMPTY_ROOT,
+    ILogger,
+    NullLogger,
+    SModelElementSchema,
+    SModelRoot,
+    TYPES,
+} from "sprotty";
+import { Action, SModelRoot as SModelRootSchema } from "sprotty-protocol";
 
 export interface LoadDiagramAction extends Action {
     kind: typeof LoadDiagramAction.KIND;
@@ -17,16 +26,12 @@ export namespace LoadDiagramAction {
 
 export class LoadDiagramCommand extends Command {
     static readonly KIND = LoadDiagramAction.KIND;
-    @inject(TYPES.ModelSource)
-    private modelSource: LocalModelSource = new LocalModelSource();
     @inject(TYPES.ILogger)
     private logger: ILogger = new NullLogger();
+    private oldRoot: SModelRoot | undefined;
+    private newRoot: SModelRoot | undefined;
 
-    constructor() {
-        super();
-    }
-
-    execute(context: CommandExecutionContext): SModelRoot {
+    async execute(context: CommandExecutionContext): Promise<SModelRoot> {
         // Open a file picker dialog.
         // The cleaner way to do this would be showOpenFilePicker(),
         // but safari and firefox don't support it at the time of writing this code:
@@ -34,7 +39,7 @@ export class LoadDiagramCommand extends Command {
         const input = document.createElement("input");
         input.type = "file";
         input.accept = ".json";
-        const fileLoadPromise = new Promise((resolve, reject) => {
+        const fileLoadPromise = new Promise<SModelRootSchema>((resolve, reject) => {
             input.onchange = () => {
                 if (input.files && input.files.length > 0) {
                     const file = input.files[0];
@@ -55,35 +60,49 @@ export class LoadDiagramCommand extends Command {
         });
         input.click();
 
-        fileLoadPromise
-            .then((model: any) => {
-                // TODO: document, move to dedicated class method
-                const removeFeatures = (model: any) => {
-                    delete model.features;
-                    if (model.children) {
-                        model.children.forEach((child: any) => removeFeatures(child));
-                    }
-                };
-                removeFeatures(model);
+        this.oldRoot = context.root;
+        try {
+            const newSchema = await fileLoadPromise;
+            this.preprocessModelSchema(newSchema);
+            this.newRoot = context.modelFactory.createRoot(newSchema);
 
-                return this.modelSource.setModel(model);
-            })
-            .then(() => {
-                this.logger.info(this, "Model loaded successfully");
-            })
-            .catch((error) => {
-                this.logger.error(this, "Error loading model", error);
-            });
-
-        return context.root;
+            this.logger.info(this, "Model loaded successfully");
+            return this.newRoot;
+        } catch (error) {
+            this.logger.error(this, "Error loading model", error);
+            return this.oldRoot;
+        }
     }
 
-    // TODO: undo and redo implementation
+    /**
+     * Before a saved model schema can be loaded, it needs to be preprocessed.
+     * Currently this means that the features property is removed from all model elements recursively,
+     * but in the future more thing may be added here.
+     *
+     * The feature property at runtime is a js Set with the relevant features.
+     * E.g. for the top graph this is the viewportFeature among others.
+     * When converting js Sets objects into json, the result is an empty js object.
+     * When loading the object is converted into an empty js Set and the features are lost.
+     * Because of this the editor won't work properly after loading a model.
+     * To prevent this, the features property is removed before loading the model.
+     * When the features property is missing it gets rebuilt on loading with the currently used features.
+     *
+     * @param modelSchema The model schema to preprocess
+     */
+    private preprocessModelSchema(modelSchema: SModelRootSchema): void {
+        // Feature is not included in the typing
+        "features" in modelSchema && delete modelSchema["features"];
+
+        if (modelSchema.children) {
+            modelSchema.children.forEach((child: any) => this.preprocessModelSchema(child));
+        }
+    }
+
     undo(context: CommandExecutionContext): SModelRoot {
-        return context.root;
+        return this.oldRoot ?? context.modelFactory.createRoot(EMPTY_ROOT);
     }
 
     redo(context: CommandExecutionContext): SModelRoot {
-        return context.root;
+        return this.newRoot ?? context.modelFactory.createRoot(EMPTY_ROOT);
     }
 }

--- a/src/commands/load.ts
+++ b/src/commands/load.ts
@@ -1,14 +1,5 @@
 import { inject } from "inversify";
-import {
-    Command,
-    CommandExecutionContext,
-    EMPTY_ROOT,
-    ILogger,
-    NullLogger,
-    SModelElementSchema,
-    SModelRoot,
-    TYPES,
-} from "sprotty";
+import { Command, CommandExecutionContext, EMPTY_ROOT, ILogger, NullLogger, SModelRoot, TYPES } from "sprotty";
 import { Action, SModelRoot as SModelRootSchema } from "sprotty-protocol";
 
 export interface LoadDiagramAction extends Action {

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -1,0 +1,62 @@
+import { inject, injectable } from "inversify";
+import { Command, CommandExecutionContext, LocalModelSource, SModelRoot, TYPES } from "sprotty";
+import { Action } from "sprotty-protocol";
+import { constructorInject } from "../utils";
+
+export interface SaveDiagramAction extends Action {
+    kind: typeof SaveDiagramAction.KIND;
+    suggestedFileName: string;
+}
+export namespace SaveDiagramAction {
+    export const KIND = "save-diagram";
+
+    export function create(suggestedFileName: string): SaveDiagramAction {
+        return {
+            kind: KIND,
+            suggestedFileName,
+        };
+    }
+}
+
+@injectable()
+export class SaveDiagramCommand extends Command {
+    static readonly KIND = SaveDiagramAction.KIND;
+    @inject(TYPES.ModelSource)
+    private modelSource: LocalModelSource = new LocalModelSource();
+
+    constructor(@constructorInject(TYPES.Action) private action: SaveDiagramAction) {
+        super();
+    }
+
+    execute(context: CommandExecutionContext): SModelRoot {
+        // Export the diagram as a JSON data URL.
+        const diagramJson = JSON.stringify(this.modelSource.model, undefined, 4);
+        const jsonBlob = new Blob([diagramJson], { type: "application/json" });
+        const jsonUrl = URL.createObjectURL(jsonBlob);
+
+        // Download the JSON file using a temporary anchor element.
+        // The cleaner way to do this would be showSaveFilePicker(),
+        // but safari and firefox don't support it at the time of writing this code:
+        // https://developer.mozilla.org/en-US/docs/web/api/window/showsavefilepicker#browser_compatibility
+        const tempLink = document.createElement("a");
+        tempLink.href = jsonUrl;
+        tempLink.setAttribute("download", this.action.suggestedFileName);
+        tempLink.click();
+
+        // Free the url data
+        URL.revokeObjectURL(jsonUrl);
+        tempLink.remove();
+
+        return context.root;
+    }
+
+    // Saving cannot be undone and should not be redone.
+
+    undo(context: CommandExecutionContext): SModelRoot {
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): SModelRoot {
+        return context.root;
+    }
+}

--- a/src/tools/commandPalette.ts
+++ b/src/tools/commandPalette.ts
@@ -16,6 +16,7 @@ import "@vscode/codicons/dist/codicon.css";
 import "sprotty/css/command-palette.css";
 import "./commandPalette.css";
 import { SaveDiagramAction } from "../commands/save";
+import { LoadDiagramAction } from "../commands/load";
 
 /**
  * Provides possible actions for the command palette.
@@ -37,6 +38,7 @@ export class ServerCommandPaletteActionProvider implements ICommandPaletteAction
             new LabeledAction("Create new edge", [EnableToolsAction.create([EdgeCreationTool.ID])], "link"),
             new LabeledAction("Fit to Screen", [fitToScreenAction], "layout"),
             new LabeledAction("Save diagram as JSON", [SaveDiagramAction.create("diagram.json")], "save"),
+            new LabeledAction("Load diagram from JSON", [LoadDiagramAction.create()], "go-to-file"),
             new LabeledAction("Export as SVG", [RequestExportSvgAction.create()], "export"),
             // TODO: this action is only used for demonstration purposes including the LogHelloAction. This should be removed
             new LabeledAction("Log Hello World", [LogHelloAction.create("from command palette hello")], "symbol-event"),

--- a/src/tools/commandPalette.ts
+++ b/src/tools/commandPalette.ts
@@ -15,6 +15,7 @@ import { EdgeCreationTool } from "./edgeCreationTool";
 import "@vscode/codicons/dist/codicon.css";
 import "sprotty/css/command-palette.css";
 import "./commandPalette.css";
+import { SaveDiagramAction } from "../commands/save";
 
 /**
  * Provides possible actions for the command palette.
@@ -35,6 +36,7 @@ export class ServerCommandPaletteActionProvider implements ICommandPaletteAction
         return [
             new LabeledAction("Create new edge", [EnableToolsAction.create([EdgeCreationTool.ID])], "link"),
             new LabeledAction("Fit to Screen", [fitToScreenAction], "layout"),
+            new LabeledAction("Save diagram as JSON", [SaveDiagramAction.create("diagram.json")], "save"),
             new LabeledAction("Export as SVG", [RequestExportSvgAction.create()], "export"),
             // TODO: this action is only used for demonstration purposes including the LogHelloAction. This should be removed
             new LabeledAction("Log Hello World", [LogHelloAction.create("from command palette hello")], "symbol-event"),


### PR DESCRIPTION
Adds commands to the command palette to download the current diagram as a json file and one to load it.