### PR TITLE
Add possibility to define node children dynamically by runtime implementation

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -3,6 +3,7 @@ import { configureCommand } from "sprotty";
 import { LogHelloCommand } from "./log-hello";
 import { SaveDiagramCommand } from "./save";
 import { LoadDiagramCommand } from "./load";
+import { LoadDefaultDiagramCommand } from "./loadDefaultDiagram";
 
 // Bundles all defined commands into a inversify module that can be loaded to make
 // all commands available to sprotty.
@@ -12,4 +13,5 @@ export const commandsModule = new ContainerModule((bind, unbind, isBound, rebind
     configureCommand(context, LogHelloCommand);
     configureCommand(context, SaveDiagramCommand);
     configureCommand(context, LoadDiagramCommand);
+    configureCommand(context, LoadDefaultDiagramCommand);
 });

--- a/src/commands/load.ts
+++ b/src/commands/load.ts
@@ -1,6 +1,6 @@
 import { Command, CommandExecutionContext, EMPTY_ROOT, ILogger, NullLogger, SModelRoot, TYPES } from "sprotty";
 import { Action, SModelRoot as SModelRootSchema } from "sprotty-protocol";
-import { DynamicChildrenModelSource } from "../dynamicChildren";
+import { DynamicChildrenProcessor } from "../dynamicChildren";
 import { inject } from "inversify";
 
 export interface LoadDiagramAction extends Action {
@@ -21,8 +21,8 @@ export class LoadDiagramCommand extends Command {
 
     @inject(TYPES.ILogger)
     private readonly logger: ILogger = new NullLogger();
-    @inject(TYPES.ModelSource)
-    private readonly modelSource: DynamicChildrenModelSource = new DynamicChildrenModelSource();
+    @inject(DynamicChildrenProcessor)
+    private readonly dynamicChildrenProcessor: DynamicChildrenProcessor = new DynamicChildrenProcessor();
 
     private oldRoot: SModelRoot | undefined;
     private newRoot: SModelRoot | undefined;
@@ -84,7 +84,7 @@ export class LoadDiagramCommand extends Command {
             }
 
             this.preprocessModelSchema(newSchema);
-            this.modelSource.processGraph(newSchema, "expand");
+            this.dynamicChildrenProcessor.processGraphChildren(newSchema, "set");
             this.newRoot = context.modelFactory.createRoot(newSchema);
 
             this.logger.info(this, "Model loaded successfully");

--- a/src/commands/load.ts
+++ b/src/commands/load.ts
@@ -1,6 +1,6 @@
 import { Command, CommandExecutionContext, EMPTY_ROOT, ILogger, NullLogger, SModelRoot, TYPES } from "sprotty";
 import { Action, SModelRoot as SModelRootSchema } from "sprotty-protocol";
-import { ExpanderModelSource } from "../modelSource";
+import { DynamicChildrenModelSource } from "../dynamicChildren";
 import { inject } from "inversify";
 
 export interface LoadDiagramAction extends Action {
@@ -22,7 +22,7 @@ export class LoadDiagramCommand extends Command {
     @inject(TYPES.ILogger)
     private readonly logger: ILogger = new NullLogger();
     @inject(TYPES.ModelSource)
-    private readonly modelSource: ExpanderModelSource = new ExpanderModelSource();
+    private readonly modelSource: DynamicChildrenModelSource = new DynamicChildrenModelSource();
 
     private oldRoot: SModelRoot | undefined;
     private newRoot: SModelRoot | undefined;

--- a/src/commands/load.ts
+++ b/src/commands/load.ts
@@ -1,8 +1,7 @@
-import { inject } from "inversify";
 import { Command, CommandExecutionContext, EMPTY_ROOT, ILogger, NullLogger, SModelRoot, TYPES } from "sprotty";
 import { Action, SModelRoot as SModelRootSchema } from "sprotty-protocol";
-import { constructorInject } from "../utils";
 import { ExpanderModelSource } from "../modelSource";
+import { inject } from "inversify";
 
 export interface LoadDiagramAction extends Action {
     kind: typeof LoadDiagramAction.KIND;
@@ -20,15 +19,13 @@ export namespace LoadDiagramAction {
 export class LoadDiagramCommand extends Command {
     static readonly KIND = LoadDiagramAction.KIND;
 
+    @inject(TYPES.ILogger)
+    private readonly logger: ILogger = new NullLogger();
+    @inject(TYPES.ModelSource)
+    private readonly modelSource: ExpanderModelSource = new ExpanderModelSource();
+
     private oldRoot: SModelRoot | undefined;
     private newRoot: SModelRoot | undefined;
-
-    constructor(
-        @constructorInject(TYPES.ILogger) private readonly logger: ILogger,
-        @constructorInject(TYPES.ModelSource) private readonly modelSource: ExpanderModelSource,
-    ) {
-        super();
-    }
 
     async execute(context: CommandExecutionContext): Promise<SModelRoot> {
         // Open a file picker dialog.
@@ -128,6 +125,6 @@ export class LoadDiagramCommand extends Command {
     }
 
     redo(context: CommandExecutionContext): SModelRoot {
-        return this.newRoot ?? context.modelFactory.createRoot(EMPTY_ROOT);
+        return this.newRoot ?? this.oldRoot ?? context.modelFactory.createRoot(EMPTY_ROOT);
     }
 }

--- a/src/commands/loadDefaultDiagram.ts
+++ b/src/commands/loadDefaultDiagram.ts
@@ -10,7 +10,7 @@ import {
     TYPES,
 } from "sprotty";
 import { Action, SGraph as SGraphSchema, SEdge as SEdgeSchema } from "sprotty-protocol";
-import { DynamicChildrenModelSource } from "../dynamicChildren";
+import { DynamicChildrenProcessor } from "../dynamicChildren";
 import { DFDNodeSchema } from "../views";
 import { generateRandomSprottyId } from "../utils";
 
@@ -77,8 +77,8 @@ export class LoadDefaultDiagramCommand extends Command {
     static readonly KIND = LoadDefaultDiagramAction.KIND;
     @inject(TYPES.ILogger)
     private readonly logger: ILogger = new NullLogger();
-    @inject(TYPES.ModelSource)
-    private readonly modelSource: DynamicChildrenModelSource = new DynamicChildrenModelSource();
+    @inject(DynamicChildrenProcessor)
+    private readonly dynamicChildrenProcessor: DynamicChildrenProcessor = new DynamicChildrenProcessor();
 
     private oldRoot: SModelRoot | undefined;
     private newRoot: SModelRoot | undefined;
@@ -87,7 +87,7 @@ export class LoadDefaultDiagramCommand extends Command {
         this.oldRoot = context.root;
 
         const graphCopy = JSON.parse(JSON.stringify(defaultDiagramSchema));
-        this.modelSource.processGraph(graphCopy, "expand");
+        this.dynamicChildrenProcessor.processGraphChildren(graphCopy, "set");
         this.newRoot = context.modelFactory.createRoot(graphCopy);
 
         this.logger.info(this, "Default Model loaded successfully");

--- a/src/commands/loadDefaultDiagram.ts
+++ b/src/commands/loadDefaultDiagram.ts
@@ -10,7 +10,7 @@ import {
     TYPES,
 } from "sprotty";
 import { Action, SGraph as SGraphSchema, SEdge as SEdgeSchema } from "sprotty-protocol";
-import { ExpanderModelSource } from "../modelSource";
+import { DynamicChildrenModelSource } from "../dynamicChildren";
 import { DFDNodeSchema } from "../views";
 import { generateRandomSprottyId } from "../utils";
 
@@ -78,7 +78,7 @@ export class LoadDefaultDiagramCommand extends Command {
     @inject(TYPES.ILogger)
     private readonly logger: ILogger = new NullLogger();
     @inject(TYPES.ModelSource)
-    private readonly modelSource: ExpanderModelSource = new ExpanderModelSource();
+    private readonly modelSource: DynamicChildrenModelSource = new DynamicChildrenModelSource();
 
     private oldRoot: SModelRoot | undefined;
     private newRoot: SModelRoot | undefined;

--- a/src/commands/loadDefaultDiagram.ts
+++ b/src/commands/loadDefaultDiagram.ts
@@ -9,7 +9,7 @@ import {
     SModelRoot,
     TYPES,
 } from "sprotty";
-import { Action, SGraph as SGraphSchema, SLabel as SLabelSchema, SEdge as SEdgeSchema } from "sprotty-protocol";
+import { Action, SGraph as SGraphSchema, SEdge as SEdgeSchema } from "sprotty-protocol";
 import { ExpanderModelSource } from "../modelSource";
 import { DFDNodeSchema } from "../views";
 
@@ -38,42 +38,18 @@ const defaultDiagramSchema: SGraphSchema = {
             position: { x: 325, y: 205 },
             size: { width: 70, height: 40 },
         } as DFDNodeSchema,
-
         {
             type: "edge:arrow",
             id: "edge01",
             sourceId: "storage01",
             targetId: "function01",
-            children: [
-                {
-                    type: "label",
-                    id: "label01",
-                    text: "Input",
-                    edgePlacement: {
-                        position: 0.5,
-                        side: "on",
-                        rotate: false,
-                    },
-                } as SLabelSchema,
-            ],
+            text: "Read",
         } as SEdgeSchema,
         {
             type: "edge:arrow",
             id: "edge02",
             sourceId: "function01",
             targetId: "input01",
-            children: [
-                {
-                    type: "label",
-                    id: "label02",
-                    text: "",
-                    edgePlacement: {
-                        position: 0.5,
-                        side: "on",
-                        rotate: false,
-                    },
-                } as SLabelSchema,
-            ],
         } as SEdgeSchema,
     ],
 };

--- a/src/commands/loadDefaultDiagram.ts
+++ b/src/commands/loadDefaultDiagram.ts
@@ -1,0 +1,123 @@
+import { inject, injectable } from "inversify";
+import {
+    Command,
+    CommandExecutionContext,
+    CommandReturn,
+    EMPTY_ROOT,
+    ILogger,
+    NullLogger,
+    SModelRoot,
+    TYPES,
+} from "sprotty";
+import { Action, SGraph as SGraphSchema, SLabel as SLabelSchema, SEdge as SEdgeSchema } from "sprotty-protocol";
+import { ExpanderModelSource } from "../modelSource";
+import { DFDNodeSchema } from "../views";
+
+const defaultDiagramSchema: SGraphSchema = {
+    type: "graph",
+    id: "root",
+    children: [
+        {
+            type: "node:storage",
+            id: "storage01",
+            text: "Database",
+            position: { x: 100, y: 100 },
+            size: { width: 60, height: 30 },
+        } as DFDNodeSchema,
+        {
+            type: "node:function",
+            id: "function01",
+            text: "System",
+            position: { x: 200, y: 200 },
+            size: { width: 50, height: 50 },
+        } as DFDNodeSchema,
+        {
+            type: "node:input-output",
+            id: "input01",
+            text: "Customer",
+            position: { x: 325, y: 205 },
+            size: { width: 70, height: 40 },
+        } as DFDNodeSchema,
+
+        {
+            type: "edge:arrow",
+            id: "edge01",
+            sourceId: "storage01",
+            targetId: "function01",
+            children: [
+                {
+                    type: "label",
+                    id: "label01",
+                    text: "Input",
+                    edgePlacement: {
+                        position: 0.5,
+                        side: "on",
+                        rotate: false,
+                    },
+                } as SLabelSchema,
+            ],
+        } as SEdgeSchema,
+        {
+            type: "edge:arrow",
+            id: "edge02",
+            sourceId: "function01",
+            targetId: "input01",
+            children: [
+                {
+                    type: "label",
+                    id: "label02",
+                    text: "",
+                    edgePlacement: {
+                        position: 0.5,
+                        side: "on",
+                        rotate: false,
+                    },
+                } as SLabelSchema,
+            ],
+        } as SEdgeSchema,
+    ],
+};
+
+export interface LoadDefaultDiagramAction extends Action {
+    readonly kind: typeof LoadDefaultDiagramAction.KIND;
+}
+export namespace LoadDefaultDiagramAction {
+    export const KIND = "loadDefaultDiagram";
+
+    export function create(): LoadDefaultDiagramAction {
+        return {
+            kind: KIND,
+        };
+    }
+}
+
+@injectable()
+export class LoadDefaultDiagramCommand extends Command {
+    static readonly KIND = LoadDefaultDiagramAction.KIND;
+    @inject(TYPES.ILogger)
+    private readonly logger: ILogger = new NullLogger();
+    @inject(TYPES.ModelSource)
+    private readonly modelSource: ExpanderModelSource = new ExpanderModelSource();
+
+    private oldRoot: SModelRoot | undefined;
+    private newRoot: SModelRoot | undefined;
+
+    execute(context: CommandExecutionContext): CommandReturn {
+        this.oldRoot = context.root;
+
+        const graphCopy = JSON.parse(JSON.stringify(defaultDiagramSchema));
+        this.modelSource.processGraph(graphCopy, "expand");
+        this.newRoot = context.modelFactory.createRoot(graphCopy);
+
+        this.logger.info(this, "Default Model loaded successfully");
+        return this.newRoot;
+    }
+
+    undo(context: CommandExecutionContext): SModelRoot {
+        return this.oldRoot ?? context.modelFactory.createRoot(EMPTY_ROOT);
+    }
+
+    redo(context: CommandExecutionContext): SModelRoot {
+        return this.newRoot ?? this.oldRoot ?? context.modelFactory.createRoot(EMPTY_ROOT);
+    }
+}

--- a/src/commands/loadDefaultDiagram.ts
+++ b/src/commands/loadDefaultDiagram.ts
@@ -12,6 +12,11 @@ import {
 import { Action, SGraph as SGraphSchema, SEdge as SEdgeSchema } from "sprotty-protocol";
 import { ExpanderModelSource } from "../modelSource";
 import { DFDNodeSchema } from "../views";
+import { generateRandomSprottyId } from "../utils";
+
+const storageId = generateRandomSprottyId();
+const functionId = generateRandomSprottyId();
+const outputId = generateRandomSprottyId();
 
 const defaultDiagramSchema: SGraphSchema = {
     type: "graph",
@@ -19,37 +24,37 @@ const defaultDiagramSchema: SGraphSchema = {
     children: [
         {
             type: "node:storage",
-            id: "storage01",
+            id: storageId,
             text: "Database",
             position: { x: 100, y: 100 },
             size: { width: 60, height: 30 },
         } as DFDNodeSchema,
         {
             type: "node:function",
-            id: "function01",
+            id: functionId,
             text: "System",
             position: { x: 200, y: 200 },
             size: { width: 50, height: 50 },
         } as DFDNodeSchema,
         {
             type: "node:input-output",
-            id: "input01",
+            id: outputId,
             text: "Customer",
             position: { x: 325, y: 205 },
             size: { width: 70, height: 40 },
         } as DFDNodeSchema,
         {
             type: "edge:arrow",
-            id: "edge01",
-            sourceId: "storage01",
-            targetId: "function01",
+            id: generateRandomSprottyId(),
+            sourceId: storageId,
+            targetId: functionId,
             text: "Read",
         } as SEdgeSchema,
         {
             type: "edge:arrow",
-            id: "edge02",
-            sourceId: "function01",
-            targetId: "input01",
+            id: generateRandomSprottyId(),
+            sourceId: functionId,
+            targetId: outputId,
         } as SEdgeSchema,
     ],
 };

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -2,7 +2,7 @@ import { inject, injectable } from "inversify";
 import { Command, CommandExecutionContext, SModelRoot, TYPES } from "sprotty";
 import { Action } from "sprotty-protocol";
 import { constructorInject } from "../utils";
-import { ExpanderModelSource } from "../modelSource";
+import { DynamicChildrenModelSource } from "../dynamicChildren";
 
 export interface SaveDiagramAction extends Action {
     kind: typeof SaveDiagramAction.KIND;
@@ -23,7 +23,7 @@ export namespace SaveDiagramAction {
 export class SaveDiagramCommand extends Command {
     static readonly KIND = SaveDiagramAction.KIND;
     @inject(TYPES.ModelSource)
-    private modelSource: ExpanderModelSource = new ExpanderModelSource();
+    private modelSource: DynamicChildrenModelSource = new DynamicChildrenModelSource();
 
     constructor(@constructorInject(TYPES.Action) private action: SaveDiagramAction) {
         super();

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -1,7 +1,8 @@
 import { inject, injectable } from "inversify";
-import { Command, CommandExecutionContext, LocalModelSource, SModelRoot, TYPES } from "sprotty";
+import { Command, CommandExecutionContext, SModelRoot, TYPES } from "sprotty";
 import { Action } from "sprotty-protocol";
 import { constructorInject } from "../utils";
+import { ExpanderModelSource } from "../modelSource";
 
 export interface SaveDiagramAction extends Action {
     kind: typeof SaveDiagramAction.KIND;
@@ -22,7 +23,7 @@ export namespace SaveDiagramAction {
 export class SaveDiagramCommand extends Command {
     static readonly KIND = SaveDiagramAction.KIND;
     @inject(TYPES.ModelSource)
-    private modelSource: LocalModelSource = new LocalModelSource();
+    private modelSource: ExpanderModelSource = new ExpanderModelSource();
 
     constructor(@constructorInject(TYPES.Action) private action: SaveDiagramAction) {
         super();

--- a/src/dynamicChildren.ts
+++ b/src/dynamicChildren.ts
@@ -1,11 +1,30 @@
 import { injectable, multiInject } from "inversify";
-import { LocalModelSource, SModelElementRegistration, SNode, SEdge, TYPES } from "sprotty";
-import {
-    SModelRoot as SModelRootSchema,
-    SModelElement as SModelElementSchema,
-    SEdge as SEdgeSchema,
-    SNode as SNodeSchema,
-} from "sprotty-protocol";
+import { SModelElementRegistration, SNode, SEdge, TYPES } from "sprotty";
+import { SModelElement as SModelElementSchema, SEdge as SEdgeSchema, SNode as SNodeSchema } from "sprotty-protocol";
+
+// This file contains helpers to dynamically specify the children of a sprotty element.
+// Element children are generally used for e.g. labels in sprotty or other sub elements.
+// You could embed everything into one element but it is often easier to use children.
+// E.g. for editable labels you would need to implement a custom label edit ui which is pretty complicated.
+
+// Normally, the children of a sprotty element are specified in the model.
+// However this means that the children are saved together with the model.
+// Imagine you want to change the children of a node at some point, e.g to add another text label,
+// move it slightly or align the text differently.
+// When you save the children you would need to migrate the previously saved models
+// to the new children.
+
+// This is undesirable as the display of a node should not be hardcoded in the serialized model.
+// To circumvent this, these helper classes were developed.
+// The model is saved without children and the children are added dynamically by the runtime
+// by each model element using the setChildren method.
+// This sets the `children` array of the element and also loads data from the parent element into the children
+// (e.g. texts for labels).
+// When the model is saved, the removeChildren method is called to remove the children again.
+// This method also needs to save the data of the children in the parent element, so it is properly saved.
+// This ensures that the display of a node is a implementation detail and not encoded in the saved models.
+
+// Abstract classes that define the both abstract methods setChildren and removeChildren
 
 export abstract class DynamicChildrenNode extends SNode {
     abstract setChildren(schema: SNodeSchema): void;
@@ -18,37 +37,36 @@ export abstract class DynamicChildrenEdge extends SEdge {
 }
 
 @injectable()
-export class DynamicChildrenModelSource extends LocalModelSource {
+export class DynamicChildrenProcessor {
     @multiInject(TYPES.SModelElementRegistration)
     private readonly elementRegistrations: SModelElementRegistration[] = [];
 
-    get model(): SModelRootSchema {
-        const copy = JSON.parse(JSON.stringify(this.currentRoot));
-        this.processGraph(copy, "retract");
-
-        return copy;
-    }
-
-    set model(root: SModelRootSchema) {
-        this.processGraph(root, "expand");
-        this.setModel(root);
-    }
-
-    public processGraph(graphElement: SModelElementSchema | SEdgeSchema, action: "expand" | "retract"): void {
+    /**
+     * Recursively either adds or removes the children of a model graph.
+     * Recursively traverses the graph, gets the registration of the corresponding element type,
+     * checks whether it extends a DynamicChildren* abstract class and then calls the corresponding method.
+     */
+    public processGraphChildren(graphElement: SModelElementSchema | SEdgeSchema, action: "set" | "remove"): void {
         const registration = this.elementRegistrations.find((r) => r.type === graphElement.type);
         if (registration) {
+            // If registration is undefined some element hasn't been registered but used, so this shouldn't happen
+            // if the model is valid.
+
+            // Create a instance of the element.
+            // Ideally the *Children methods should be static, but static methods can't be abstract.
+            // So we need to create a instance we can then call the method on.
             const impl = new registration.constr();
             if (impl instanceof DynamicChildrenNode) {
-                if (action === "expand") {
+                if (action === "set") {
                     impl.setChildren(graphElement);
                 } else {
                     impl.removeChildren(graphElement);
                 }
             }
 
+            // sourceId is only present in edges and ensures that the graphElement is an edge (to calm the type system)
             if (impl instanceof DynamicChildrenEdge && "sourceId" in graphElement) {
-                // sourceId is only present in edges and ensures that the graphElement is an edge (to calm the type system)
-                if (action === "expand") {
+                if (action === "set") {
                     impl.setChildren(graphElement);
                 } else {
                     impl.removeChildren(graphElement);
@@ -56,6 +74,6 @@ export class DynamicChildrenModelSource extends LocalModelSource {
             }
         }
 
-        graphElement.children?.forEach((child) => this.processGraph(child, action));
+        graphElement.children?.forEach((child) => this.processGraphChildren(child, action));
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import {
 import { toolsModules } from "./tools";
 import { commandsModule } from "./commands/commands";
 import { ToolPaletteUI } from "./tools/toolPalette";
+import { ExpanderModelSource } from "./modelSource";
 
 import "sprotty/css/sprotty.css";
 import "sprotty/css/edit-label.css";
@@ -60,10 +61,11 @@ import "./page.css";
 // Setup the Dependency Injection Container.
 // This includes all used nodes, edges, listeners, etc. for sprotty.
 const dataFlowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(TYPES.ModelSource).to(LocalModelSource).inSingletonScope();
+    bind(TYPES.ModelSource).to(ExpanderModelSource).inSingletonScope();
     rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
     rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
     bind(TYPES.ISnapper).to(CenterGridSnapper);
+
     const context = { bind, unbind, isBound, rebind };
     configureModelElement(context, "graph", SGraph, SGraphView);
     configureModelElement(context, "node:storage", RectangularDFDNode, StorageNodeView);
@@ -191,17 +193,14 @@ const graph: SGraphSchema = {
 // Unless overwritten this will load the graph into the DOM element with the id "sprotty".
 const modelSource = container.get<LocalModelSource>(TYPES.ModelSource);
 const dispatcher = container.get<ActionDispatcher>(TYPES.IActionDispatcher);
-modelSource
-    .setModel(graph)
-    .then(() => {
-        console.log("Sprotty model set.");
 
-        // Show the tool palette after startup has completed.
-        dispatcher.dispatch(
-            SetUIExtensionVisibilityAction.create({
-                extensionId: ToolPaletteUI.ID,
-                visible: true,
-            }),
-        );
-    })
-    .catch((reason) => console.error(reason));
+modelSource.model = graph;
+console.log("Sprotty model set.");
+
+// Show the tool palette after startup has completed.
+dispatcher.dispatch(
+    SetUIExtensionVisibilityAction.create({
+        extensionId: ToolPaletteUI.ID,
+        visible: true,
+    }),
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,23 +6,20 @@ import {
     StorageNodeView,
     ArrowEdgeView,
     ArrowEdge,
-    DFDNodeSchema,
     RectangularDFDNode,
     CircularDFDNode,
+    DFDLabelView,
 } from "./views";
 import { Container, ContainerModule } from "inversify";
-import { SEdge as SEdgeSchema, SGraph as SGraphSchema, SLabel as SLabelSchema } from "sprotty-protocol";
 import {
     ActionDispatcher,
     CenterGridSnapper,
     ConsoleLogger,
     CreateElementCommand,
-    LocalModelSource,
     LogLevel,
     SGraph,
     SGraphView,
     SLabel,
-    SLabelView,
     SRoutingHandle,
     SRoutingHandleView,
     SetUIExtensionVisibilityAction,
@@ -57,6 +54,7 @@ import "sprotty/css/edit-label.css";
 
 import "./theme.css";
 import "./page.css";
+import { LoadDefaultDiagramAction } from "./commands/loadDefaultDiagram";
 
 // Setup the Dependency Injection Container.
 // This includes all used nodes, edges, listeners, etc. for sprotty.
@@ -74,7 +72,7 @@ const dataFlowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
     configureModelElement(context, "edge:arrow", ArrowEdge, ArrowEdgeView, {
         enable: [withEditLabelFeature],
     });
-    configureModelElement(context, "label", SLabel, SLabelView, {
+    configureModelElement(context, "label", SLabel, DFDLabelView, {
         enable: [editLabelFeature],
     });
     configureModelElement(context, "routing-point", SRoutingHandle, SRoutingHandleView);
@@ -123,79 +121,9 @@ container.load(
     commandsModule,
 );
 
-// Construct the diagram graph state that should be shown.
-const graph: SGraphSchema = {
-    type: "graph",
-    id: "root",
-    children: [
-        {
-            type: "node:storage",
-            id: "storage01",
-            text: "Database",
-            position: { x: 100, y: 100 },
-            size: { width: 60, height: 30 },
-        } as DFDNodeSchema,
-        {
-            type: "node:function",
-            id: "function01",
-            text: "System",
-            position: { x: 200, y: 200 },
-            size: { width: 50, height: 50 },
-        } as DFDNodeSchema,
-        {
-            type: "node:input-output",
-            id: "input01",
-            text: "Customer",
-            position: { x: 325, y: 205 },
-            size: { width: 70, height: 40 },
-        } as DFDNodeSchema,
-
-        {
-            type: "edge:arrow",
-            id: "edge01",
-            sourceId: "storage01",
-            targetId: "function01",
-            children: [
-                {
-                    type: "label",
-                    id: "label01",
-                    text: "Input",
-                    edgePlacement: {
-                        position: 0.5,
-                        side: "on",
-                        rotate: false,
-                    },
-                } as SLabelSchema,
-            ],
-        } as SEdgeSchema,
-        {
-            type: "edge:arrow",
-            id: "edge02",
-            sourceId: "function01",
-            targetId: "input01",
-            children: [
-                {
-                    type: "label",
-                    id: "label02",
-                    text: "",
-                    edgePlacement: {
-                        position: 0.5,
-                        side: "on",
-                        rotate: false,
-                    },
-                } as SLabelSchema,
-            ],
-        } as SEdgeSchema,
-    ],
-};
-
 // Load the graph into the model source and display it inside the DOM.
 // Unless overwritten this will load the graph into the DOM element with the id "sprotty".
-const modelSource = container.get<LocalModelSource>(TYPES.ModelSource);
 const dispatcher = container.get<ActionDispatcher>(TYPES.IActionDispatcher);
-
-modelSource.model = graph;
-console.log("Sprotty model set.");
 
 // Show the tool palette after startup has completed.
 dispatcher.dispatch(
@@ -204,3 +132,6 @@ dispatcher.dispatch(
         visible: true,
     }),
 );
+
+// Load the default diagram
+dispatcher.dispatch(LoadDefaultDiagramAction.create());

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ import { toolsModules } from "./tools";
 import { commandsModule } from "./commands/commands";
 import { LoadDefaultDiagramAction } from "./commands/loadDefaultDiagram";
 import { ToolPaletteUI } from "./tools/toolPalette";
-import { ExpanderModelSource } from "./modelSource";
+import { DynamicChildrenModelSource } from "./dynamicChildren";
 
 import "sprotty/css/sprotty.css";
 import "sprotty/css/edit-label.css";
@@ -59,7 +59,7 @@ import "./page.css";
 // Setup the Dependency Injection Container.
 // This includes all used nodes, edges, listeners, etc. for sprotty.
 const dataFlowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(TYPES.ModelSource).to(ExpanderModelSource).inSingletonScope();
+    bind(TYPES.ModelSource).to(DynamicChildrenModelSource).inSingletonScope();
     rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
     rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
     bind(TYPES.ISnapper).to(CenterGridSnapper);
@@ -122,7 +122,7 @@ container.load(
 );
 
 // Unless overwritten this the graph will be loaded into the DOM element with the id "sprotty".
-const modelSource = container.get<ExpanderModelSource>(TYPES.ModelSource);
+const modelSource = container.get<DynamicChildrenModelSource>(TYPES.ModelSource);
 const dispatcher = container.get<ActionDispatcher>(TYPES.IActionDispatcher);
 
 // Load the initial root model

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
     CenterGridSnapper,
     ConsoleLogger,
     CreateElementCommand,
+    LocalModelSource,
     LogLevel,
     SGraph,
     SGraphView,
@@ -48,21 +49,22 @@ import { toolsModules } from "./tools";
 import { commandsModule } from "./commands/commands";
 import { LoadDefaultDiagramAction } from "./commands/loadDefaultDiagram";
 import { ToolPaletteUI } from "./tools/toolPalette";
-import { DynamicChildrenModelSource } from "./dynamicChildren";
 
 import "sprotty/css/sprotty.css";
 import "sprotty/css/edit-label.css";
 
 import "./theme.css";
 import "./page.css";
+import { DynamicChildrenProcessor } from "./dynamicChildren";
 
 // Setup the Dependency Injection Container.
 // This includes all used nodes, edges, listeners, etc. for sprotty.
 const dataFlowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(TYPES.ModelSource).to(DynamicChildrenModelSource).inSingletonScope();
+    bind(TYPES.ModelSource).to(LocalModelSource).inSingletonScope();
     rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
     rebind(TYPES.LogLevel).toConstantValue(LogLevel.log);
     bind(TYPES.ISnapper).to(CenterGridSnapper);
+    bind(DynamicChildrenProcessor).toSelf().inSingletonScope();
 
     const context = { bind, unbind, isBound, rebind };
     configureModelElement(context, "graph", SGraph, SGraphView);
@@ -121,11 +123,11 @@ container.load(
     commandsModule,
 );
 
-// Unless overwritten this the graph will be loaded into the DOM element with the id "sprotty".
-const modelSource = container.get<DynamicChildrenModelSource>(TYPES.ModelSource);
+const modelSource = container.get<LocalModelSource>(TYPES.ModelSource);
 const dispatcher = container.get<ActionDispatcher>(TYPES.IActionDispatcher);
 
 // Load the initial root model
+// Unless overwritten this the graph will be loaded into the DOM element with the id "sprotty".
 modelSource
     .setModel({
         type: "graph",

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import {
 } from "sprotty";
 import { toolsModules } from "./tools";
 import { commandsModule } from "./commands/commands";
+import { LoadDefaultDiagramAction } from "./commands/loadDefaultDiagram";
 import { ToolPaletteUI } from "./tools/toolPalette";
 import { ExpanderModelSource } from "./modelSource";
 
@@ -54,7 +55,6 @@ import "sprotty/css/edit-label.css";
 
 import "./theme.css";
 import "./page.css";
-import { LoadDefaultDiagramAction } from "./commands/loadDefaultDiagram";
 
 // Setup the Dependency Injection Container.
 // This includes all used nodes, edges, listeners, etc. for sprotty.

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,17 +121,26 @@ container.load(
     commandsModule,
 );
 
-// Load the graph into the model source and display it inside the DOM.
-// Unless overwritten this will load the graph into the DOM element with the id "sprotty".
+// Unless overwritten this the graph will be loaded into the DOM element with the id "sprotty".
+const modelSource = container.get<ExpanderModelSource>(TYPES.ModelSource);
 const dispatcher = container.get<ActionDispatcher>(TYPES.IActionDispatcher);
 
-// Show the tool palette after startup has completed.
-dispatcher.dispatch(
-    SetUIExtensionVisibilityAction.create({
-        extensionId: ToolPaletteUI.ID,
-        visible: true,
-    }),
-);
+// Load the initial root model
+modelSource
+    .setModel({
+        type: "graph",
+        id: "root",
+        children: [],
+    })
+    .then(() => {
+        // Show the tool palette after startup has completed.
+        dispatcher.dispatch(
+            SetUIExtensionVisibilityAction.create({
+                extensionId: ToolPaletteUI.ID,
+                visible: true,
+            }),
+        );
 
-// Load the default diagram
-dispatcher.dispatch(LoadDefaultDiagramAction.create());
+        // Load the default diagram
+        dispatcher.dispatch(LoadDefaultDiagramAction.create());
+    });

--- a/src/modelSource.ts
+++ b/src/modelSource.ts
@@ -1,7 +1,11 @@
 import { injectable, multiInject } from "inversify";
 import { LocalModelSource, SModelElementRegistration, TYPES } from "sprotty";
-import { SModelRoot as SModelRootSchema, SModelElement as SModelElementSchema } from "sprotty-protocol";
-import { ExpandableView } from "./views";
+import {
+    SModelRoot as SModelRootSchema,
+    SModelElement as SModelElementSchema,
+    SEdge as SEdgeSchema,
+} from "sprotty-protocol";
+import { ExpandableEdge, ExpandableNode } from "./views";
 
 @injectable()
 export class ExpanderModelSource extends LocalModelSource {
@@ -20,11 +24,20 @@ export class ExpanderModelSource extends LocalModelSource {
         this.setModel(root);
     }
 
-    public processGraph(graphElement: SModelElementSchema, action: "expand" | "retract"): void {
+    public processGraph(graphElement: SModelElementSchema | SEdgeSchema, action: "expand" | "retract"): void {
         const registration = this.elementRegistrations.find((r) => r.type === graphElement.type);
         if (registration) {
             const impl = new registration.constr();
-            if (impl instanceof ExpandableView) {
+            if (impl instanceof ExpandableNode) {
+                if (action === "expand") {
+                    impl.expand(graphElement);
+                } else {
+                    impl.retract(graphElement);
+                }
+            }
+
+            if (impl instanceof ExpandableEdge && "sourceId" in graphElement) {
+                // sourceId is only present in edges and ensures that the graphElement is an edge (to calm the type system)
                 if (action === "expand") {
                     impl.expand(graphElement);
                 } else {

--- a/src/modelSource.ts
+++ b/src/modelSource.ts
@@ -1,0 +1,38 @@
+import { injectable, multiInject } from "inversify";
+import { LocalModelSource, SModelElementRegistration, TYPES } from "sprotty";
+import { SModelRoot as SModelRootSchema, SModelElement as SModelElementSchema } from "sprotty-protocol";
+import { ExpandableView } from "./views";
+
+@injectable()
+export class ExpanderModelSource extends LocalModelSource {
+    @multiInject(TYPES.SModelElementRegistration)
+    private readonly elementRegistrations: SModelElementRegistration[] = [];
+
+    get model(): SModelRootSchema {
+        const copy = JSON.parse(JSON.stringify(this.currentRoot));
+        this.processGraph(copy, "retract");
+
+        return copy;
+    }
+
+    set model(root: SModelRootSchema) {
+        this.processGraph(root, "expand");
+        this.setModel(root);
+    }
+
+    public processGraph(graphElement: SModelElementSchema, action: "expand" | "retract"): void {
+        const registration = this.elementRegistrations.find((r) => r.type === graphElement.type);
+        if (registration) {
+            const impl = new registration.constr();
+            if (impl instanceof ExpandableView) {
+                if (action === "expand") {
+                    impl.expand(graphElement);
+                } else {
+                    impl.retract(graphElement);
+                }
+            }
+        }
+
+        graphElement.children?.forEach((child) => this.processGraph(child, action));
+    }
+}

--- a/src/tools/commandPalette.ts
+++ b/src/tools/commandPalette.ts
@@ -17,6 +17,7 @@ import "sprotty/css/command-palette.css";
 import "./commandPalette.css";
 import { SaveDiagramAction } from "../commands/save";
 import { LoadDiagramAction } from "../commands/load";
+import { LoadDefaultDiagramAction } from "../commands/loadDefaultDiagram";
 
 /**
  * Provides possible actions for the command palette.
@@ -40,6 +41,7 @@ export class ServerCommandPaletteActionProvider implements ICommandPaletteAction
             new LabeledAction("Save diagram as JSON", [SaveDiagramAction.create("diagram.json")], "save"),
             new LabeledAction("Load diagram from JSON", [LoadDiagramAction.create()], "go-to-file"),
             new LabeledAction("Export as SVG", [RequestExportSvgAction.create()], "export"),
+            new LabeledAction("Load default diagram", [LoadDefaultDiagramAction.create()], "clear-all"),
             // TODO: this action is only used for demonstration purposes including the LogHelloAction. This should be removed
             new LabeledAction("Log Hello World", [LogHelloAction.create("from command palette hello")], "symbol-event"),
         ];

--- a/src/tools/mouseDroppableListener.ts
+++ b/src/tools/mouseDroppableListener.ts
@@ -3,7 +3,7 @@ import { MouseListener, TYPES, Tool, MouseTool } from "sprotty";
 import { CreateElementAction, SNode as SNodeSchema } from "sprotty-protocol";
 import { SModelElement, Action } from "sprotty-protocol";
 import { EDITOR_TYPES, constructorInject, generateRandomSprottyId } from "../utils";
-import { ExpanderModelSource } from "../modelSource";
+import { DynamicChildrenModelSource } from "../dynamicChildren";
 
 /**
  * When dragging a node from the new element row from the top of the page to
@@ -13,7 +13,7 @@ import { ExpanderModelSource } from "../modelSource";
  */
 @injectable()
 class MouseDroppableListener extends MouseListener {
-    constructor(@constructorInject(TYPES.ModelSource) protected modelSource: ExpanderModelSource) {
+    constructor(@constructorInject(TYPES.ModelSource) protected modelSource: DynamicChildrenModelSource) {
         super();
     }
 

--- a/src/tools/mouseDroppableListener.ts
+++ b/src/tools/mouseDroppableListener.ts
@@ -1,9 +1,9 @@
 import { ContainerModule, injectable } from "inversify";
-import { MouseListener, TYPES, Tool, MouseTool } from "sprotty";
+import { MouseListener, TYPES, Tool, MouseTool, LocalModelSource } from "sprotty";
 import { CreateElementAction, SNode as SNodeSchema } from "sprotty-protocol";
 import { SModelElement, Action } from "sprotty-protocol";
 import { EDITOR_TYPES, constructorInject, generateRandomSprottyId } from "../utils";
-import { DynamicChildrenModelSource } from "../dynamicChildren";
+import { DynamicChildrenProcessor } from "../dynamicChildren";
 
 /**
  * When dragging a node from the new element row from the top of the page to
@@ -13,7 +13,10 @@ import { DynamicChildrenModelSource } from "../dynamicChildren";
  */
 @injectable()
 class MouseDroppableListener extends MouseListener {
-    constructor(@constructorInject(TYPES.ModelSource) protected modelSource: DynamicChildrenModelSource) {
+    constructor(
+        @constructorInject(TYPES.ModelSource) protected modelSource: LocalModelSource,
+        @constructorInject(DynamicChildrenProcessor) protected dynamicChildrenProcessor: DynamicChildrenProcessor,
+    ) {
         super();
     }
 
@@ -54,7 +57,7 @@ class MouseDroppableListener extends MouseListener {
                 };
 
                 // Add children of this element to the diagram.
-                this.modelSource.processGraph(nodeData, "expand");
+                this.dynamicChildrenProcessor.processGraphChildren(nodeData, "set");
 
                 // Add the node to the diagram.
                 return CreateElementAction.create(nodeData, {

--- a/src/tools/mouseDroppableListener.ts
+++ b/src/tools/mouseDroppableListener.ts
@@ -1,8 +1,9 @@
 import { ContainerModule, injectable } from "inversify";
-import { MouseListener, TYPES, LocalModelSource, Tool, MouseTool } from "sprotty";
+import { MouseListener, TYPES, Tool, MouseTool } from "sprotty";
 import { CreateElementAction, SNode as SNodeSchema } from "sprotty-protocol";
 import { SModelElement, Action } from "sprotty-protocol";
 import { EDITOR_TYPES, constructorInject, generateRandomSprottyId } from "../utils";
+import { ExpanderModelSource } from "../modelSource";
 
 /**
  * When dragging a node from the new element row from the top of the page to
@@ -12,7 +13,7 @@ import { EDITOR_TYPES, constructorInject, generateRandomSprottyId } from "../uti
  */
 @injectable()
 class MouseDroppableListener extends MouseListener {
-    constructor(@constructorInject(TYPES.ModelSource) protected modelSource: LocalModelSource) {
+    constructor(@constructorInject(TYPES.ModelSource) protected modelSource: ExpanderModelSource) {
         super();
     }
 
@@ -51,6 +52,9 @@ class MouseDroppableListener extends MouseListener {
                     x: viewport.scroll.x + adjust(event.offsetX, nodeData.size.width),
                     y: viewport.scroll.y + adjust(event.offsetY, nodeData.size.height),
                 };
+
+                // Add children of this element to the diagram.
+                this.modelSource.processGraph(nodeData, "expand");
 
                 // Add the node to the diagram.
                 return CreateElementAction.create(nodeData, {

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -85,14 +85,15 @@ export class StorageNodeView implements IView {
         const height = node.size.height;
         return (
             <g class-sprotty-node={true} class-storage={true}>
-                <line x1="0" y1="0" x2={width} y2="0" />
-                {context.renderChildren(node)}
-                <line x1="0" y1={height} x2={width} y2={height} />
                 {/* This transparent rect exists only to make this element easily selectable.
                     Without this you would need click the text or exactly hit one of the lines.
                     With this rect you can click anywhere between the two lines to select it.
                     This is especially important when there is no text given or it is short. */}
                 <rect x="0" y="0" width={width} height={height} class-select-rect={true} />
+
+                <line x1="0" y1="0" x2={width} y2="0" />
+                {context.renderChildren(node)}
+                <line x1="0" y1={height} x2={width} y2={height} />
             </g>
         );
     }

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -12,6 +12,8 @@ import {
     WithEditableLabel,
     isEditableLabel,
     withEditLabelFeature,
+    ShapeView,
+    SLabel,
 } from "sprotty";
 import { injectable } from "inversify";
 import { VNode } from "snabbdom";
@@ -42,7 +44,6 @@ export class RectangularDFDNode extends ExpandableView implements WithEditableLa
             type: "label",
             text: schema.text,
             id: schema.id + "-label",
-            position: { x: width / 6, y: height / 4 },
         } as SLabelSchema;
 
         schema.children = [label];
@@ -92,14 +93,12 @@ export class StorageNodeView implements IView {
 
 @injectable()
 export class FunctionNodeView implements IView {
-    render(node: Readonly<CircularDFDNode>, _context: RenderingContext): VNode {
+    render(node: Readonly<CircularDFDNode>, context: RenderingContext): VNode {
         const radius = Math.min(node.size.width, node.size.height) / 2;
         return (
             <g class-sprotty-node={true} class-function={true}>
                 <circle r={radius} cx={radius} cy={radius} />
-                <text x={radius} y={radius + 5}>
-                    {node.text}
-                </text>
+                {context.renderChildren(node)}
             </g>
         );
     }
@@ -107,16 +106,14 @@ export class FunctionNodeView implements IView {
 
 @injectable()
 export class IONodeView implements IView {
-    render(node: Readonly<RectangularDFDNode>, _context: RenderingContext): VNode {
+    render(node: Readonly<RectangularDFDNode>, context: RenderingContext): VNode {
         const width = node.size.width;
         const height = node.size.height;
 
         return (
             <g class-sprotty-node={true} class-io={true}>
                 <rect x="0" y="0" width={width} height={height} />
-                <text x={width / 2} y={height / 2 + 5}>
-                    {node.text}
-                </text>
+                {context.renderChildren(node)}
             </g>
         );
     }
@@ -180,5 +177,20 @@ export class ArrowEdgeView extends PolylineEdgeViewWithGapsOnIntersections {
             }
         }
         return <path d={path} />;
+    }
+}
+
+@injectable()
+export class DFDLabelView extends ShapeView {
+    render(label: Readonly<SLabel>, _context: RenderingContext): VNode | undefined {
+        const parentSize = (label.parent as SNode | undefined)?.size;
+        const width = parentSize?.width ?? 0;
+        const height = parentSize?.height ?? 0;
+
+        return (
+            <text class-sprotty-label={true} x={width / 2} y={height / 2 + 5}>
+                {label.text}
+            </text>
+        );
     }
 }

--- a/src/views.tsx
+++ b/src/views.tsx
@@ -26,27 +26,18 @@ import { injectable } from "inversify";
 import { VNode } from "snabbdom";
 
 import "./views.css";
-
-export abstract class ExpandableNode extends SNode {
-    abstract expand(schema: SNodeSchema): void;
-    abstract retract(schema: SNodeSchema): void;
-}
-
-export abstract class ExpandableEdge extends SEdge {
-    abstract expand(schema: SEdgeSchema): void;
-    abstract retract(schema: SEdgeSchema): void;
-}
+import { DynamicChildrenEdge, DynamicChildrenNode } from "./dynamicChildren";
 
 export interface DFDNodeSchema extends SNodeSchema {
     text: string;
 }
 
-export class RectangularDFDNode extends ExpandableNode implements WithEditableLabel {
+export class RectangularDFDNode extends DynamicChildrenNode implements WithEditableLabel {
     static readonly DEFAULT_FEATURES = [...SNode.DEFAULT_FEATURES, withEditLabelFeature];
 
     text: string = "";
 
-    override expand(schema: DFDNodeSchema): void {
+    override setChildren(schema: DFDNodeSchema): void {
         schema.children = [
             {
                 type: "label",
@@ -56,7 +47,7 @@ export class RectangularDFDNode extends ExpandableNode implements WithEditableLa
         ];
     }
 
-    override retract(schema: DFDNodeSchema): void {
+    override removeChildren(schema: DFDNodeSchema): void {
         const label = schema.children?.find((element) => element.type === "label") as SLabelSchema | undefined;
         schema.text = label?.text ?? "";
         schema.children = [];
@@ -131,8 +122,8 @@ export interface ArrowEdgeSchema extends SEdgeSchema {
     text: string;
 }
 
-export class ArrowEdge extends ExpandableEdge implements WithEditableLabel {
-    expand(schema: ArrowEdgeSchema): void {
+export class ArrowEdge extends DynamicChildrenEdge implements WithEditableLabel {
+    setChildren(schema: ArrowEdgeSchema): void {
         schema.children = [
             {
                 type: "label",
@@ -147,7 +138,7 @@ export class ArrowEdge extends ExpandableEdge implements WithEditableLabel {
         ];
     }
 
-    retract(schema: ArrowEdgeSchema): void {
+    removeChildren(schema: ArrowEdgeSchema): void {
         const label = schema.children?.find((element) => element.type === "label") as SLabelSchema | undefined;
         schema.text = label?.text ?? "";
         schema.children = [];


### PR DESCRIPTION
(As disussed in the meeting on 2023-06-21)

Many things are only really doable in sprotty by using node children e.g. changing labels without removing the element while editing, having multiple labels that can be edited in one node, labels on edges.
Children must be inside the graph schema. This means the definition of the labels(position, etc.) is saved in the model json file. If we were to change the structure of the nodes this would only apply to newly created elements and the old ones would still have the old layout.
This PR introduces a way to define the node children dynamically by the runtime. When loading a element the children array is overwritten by the current implementation by the node. When saving the children array is removed and the values of the children are saved in the parent node data.

- [x] initial implementation in load and save
- [x] implement in nodes
- [x] implement in `ArrowEdge`
- [x] automatically expand when creating new elements
- [x] proper naming of interfaces, classes, method names, etc.
- [x] add proper code comments