### PR TITLE
Automatically resize nodes based on content

### DIFF
--- a/src/commands/loadDefaultDiagram.ts
+++ b/src/commands/loadDefaultDiagram.ts
@@ -29,21 +29,18 @@ const defaultDiagramSchema: SGraphSchema = {
             id: storageId,
             text: "Database",
             position: { x: 100, y: 100 },
-            size: { width: 60, height: 30 },
         } as DFDNodeSchema,
         {
             type: "node:function",
             id: functionId,
             text: "System",
             position: { x: 200, y: 200 },
-            size: { width: 50, height: 50 },
         } as DFDNodeSchema,
         {
             type: "node:input-output",
             id: outputId,
             text: "Customer",
-            position: { x: 325, y: 205 },
-            size: { width: 70, height: 40 },
+            position: { x: 325, y: 206 },
         } as DFDNodeSchema,
         {
             type: "edge:arrow",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,10 @@ import {
     StorageNodeView,
     ArrowEdgeView,
     ArrowEdge,
-    RectangularDFDNode,
-    CircularDFDNode,
+    FunctionNode,
     DFDLabelView,
+    StorageNode,
+    IONode,
 } from "./views";
 import { Container, ContainerModule } from "inversify";
 import {
@@ -69,9 +70,9 @@ const dataFlowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
 
     const context = { bind, unbind, isBound, rebind };
     configureModelElement(context, "graph", SGraph, SGraphView);
-    configureModelElement(context, "node:storage", RectangularDFDNode, StorageNodeView);
-    configureModelElement(context, "node:function", CircularDFDNode, FunctionNodeView);
-    configureModelElement(context, "node:input-output", RectangularDFDNode, IONodeView);
+    configureModelElement(context, "node:storage", StorageNode, StorageNodeView);
+    configureModelElement(context, "node:function", FunctionNode, FunctionNodeView);
+    configureModelElement(context, "node:input-output", IONode, IONodeView);
     configureModelElement(context, "edge:arrow", ArrowEdge, ArrowEdgeView, {
         enable: [withEditLabelFeature],
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,3 +31,18 @@ export function constructorInject(
 export function generateRandomSprottyId(): string {
     return Math.random().toString(36).substring(7);
 }
+
+const context = document.createElement("canvas").getContext("2d");
+export function calculateTextWidth(text: string | undefined, font: string = "11pt sans-serif"): number {
+    if (!context) {
+        throw new Error("Could not create canvas context used to measure text width");
+    }
+
+    if (!text || text.length === 0) {
+        return 20;
+    }
+
+    context.font = font;
+    const metrics = context.measureText(text);
+    return Math.round(metrics.width);
+}


### PR DESCRIPTION
Dynamically computes the size of the nodes before displaying them.
When the content of a node is changed, the size automatically gets re-computed and updated.
After this change, the size will no longer be saved inside the diagram json and be set to `-1` by sprotty.
The nodes have automatic minimum/maximum sizes where it makes sense.