### PR TITLE
Implement auto-layouting using sprotty elk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,15 +15,16 @@
                 "pretty-quick": "^3.1.3",
                 "reflect-metadata": "^0.1.13",
                 "sprotty": "^0.13.0",
+                "sprotty-elk": "^0.13.1",
                 "sprotty-protocol": "^0.13.0",
                 "typescript": "^5.0.2",
                 "vite": "^4.3.2"
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.18.tgz",
-            "integrity": "sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.17.tgz",
+            "integrity": "sha512-wHsmJG/dnL3OkpAcwbgoBTTMHVi4Uyou3F5mf58ZtmUyIKfcdA7TROav/6tCzET4A3QW2Q2FC+eFneMU+iyOxg==",
             "cpu": [
                 "arm"
             ],
@@ -37,9 +38,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.18.tgz",
-            "integrity": "sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.17.tgz",
+            "integrity": "sha512-9np+YYdNDed5+Jgr1TdWBsozZ85U1Oa3xW0c7TWqH0y2aGghXtZsuT8nYRbzOMcl0bXZXjOGbksoTtVOlWrRZg==",
             "cpu": [
                 "arm64"
             ],
@@ -53,9 +54,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.18.tgz",
-            "integrity": "sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.17.tgz",
+            "integrity": "sha512-O+FeWB/+xya0aLg23hHEM2E3hbfwZzjqumKMSIqcHbNvDa+dza2D0yLuymRBQQnC34CWrsJUXyH2MG5VnLd6uw==",
             "cpu": [
                 "x64"
             ],
@@ -69,9 +70,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.18.tgz",
-            "integrity": "sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.17.tgz",
+            "integrity": "sha512-M9uJ9VSB1oli2BE/dJs3zVr9kcCBBsE883prage1NWz6pBS++1oNn/7soPNS3+1DGj0FrkSvnED4Bmlu1VAE9g==",
             "cpu": [
                 "arm64"
             ],
@@ -85,9 +86,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.18.tgz",
-            "integrity": "sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.17.tgz",
+            "integrity": "sha512-XDre+J5YeIJDMfp3n0279DFNrGCXlxOuGsWIkRb1NThMZ0BsrWXoTg23Jer7fEXQ9Ye5QjrvXpxnhzl3bHtk0g==",
             "cpu": [
                 "x64"
             ],
@@ -101,9 +102,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.18.tgz",
-            "integrity": "sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.17.tgz",
+            "integrity": "sha512-cjTzGa3QlNfERa0+ptykyxs5A6FEUQQF0MuilYXYBGdBxD3vxJcKnzDlhDCa1VAJCmAxed6mYhA2KaJIbtiNuQ==",
             "cpu": [
                 "arm64"
             ],
@@ -117,9 +118,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.18.tgz",
-            "integrity": "sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.17.tgz",
+            "integrity": "sha512-sOxEvR8d7V7Kw8QqzxWc7bFfnWnGdaFBut1dRUYtu+EIRXefBc/eIsiUiShnW0hM3FmQ5Zf27suDuHsKgZ5QrA==",
             "cpu": [
                 "x64"
             ],
@@ -133,9 +134,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.18.tgz",
-            "integrity": "sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.17.tgz",
+            "integrity": "sha512-2d3Lw6wkwgSLC2fIvXKoMNGVaeY8qdN0IC3rfuVxJp89CRfA3e3VqWifGDfuakPmp90+ZirmTfye1n4ncjv2lg==",
             "cpu": [
                 "arm"
             ],
@@ -149,9 +150,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.18.tgz",
-            "integrity": "sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.17.tgz",
+            "integrity": "sha512-c9w3tE7qA3CYWjT+M3BMbwMt+0JYOp3vCMKgVBrCl1nwjAlOMYzEo+gG7QaZ9AtqZFj5MbUc885wuBBmu6aADQ==",
             "cpu": [
                 "arm64"
             ],
@@ -165,9 +166,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.18.tgz",
-            "integrity": "sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.17.tgz",
+            "integrity": "sha512-1DS9F966pn5pPnqXYz16dQqWIB0dmDfAQZd6jSSpiT9eX1NzKh07J6VKR3AoXXXEk6CqZMojiVDSZi1SlmKVdg==",
             "cpu": [
                 "ia32"
             ],
@@ -181,9 +182,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.18.tgz",
-            "integrity": "sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.17.tgz",
+            "integrity": "sha512-EvLsxCk6ZF0fpCB6w6eOI2Fc8KW5N6sHlIovNe8uOFObL2O+Mr0bflPHyHwLT6rwMg9r77WOAWb2FqCQrVnwFg==",
             "cpu": [
                 "loong64"
             ],
@@ -197,9 +198,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.18.tgz",
-            "integrity": "sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.17.tgz",
+            "integrity": "sha512-e0bIdHA5p6l+lwqTE36NAW5hHtw2tNRmHlGBygZC14QObsA3bD4C6sXLJjvnDIjSKhW1/0S3eDy+QmX/uZWEYQ==",
             "cpu": [
                 "mips64el"
             ],
@@ -213,9 +214,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.18.tgz",
-            "integrity": "sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.17.tgz",
+            "integrity": "sha512-BAAilJ0M5O2uMxHYGjFKn4nJKF6fNCdP1E0o5t5fvMYYzeIqy2JdAP88Az5LHt9qBoUa4tDaRpfWt21ep5/WqQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -229,9 +230,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.18.tgz",
-            "integrity": "sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.17.tgz",
+            "integrity": "sha512-Wh/HW2MPnC3b8BqRSIme/9Zhab36PPH+3zam5pqGRH4pE+4xTrVLx2+XdGp6fVS3L2x+DrsIcsbMleex8fbE6g==",
             "cpu": [
                 "riscv64"
             ],
@@ -245,9 +246,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.18.tgz",
-            "integrity": "sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.17.tgz",
+            "integrity": "sha512-j/34jAl3ul3PNcK3pfI0NSlBANduT2UO5kZ7FCaK33XFv3chDhICLY8wJJWIhiQ+YNdQ9dxqQctRg2bvrMlYgg==",
             "cpu": [
                 "s390x"
             ],
@@ -261,9 +262,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.18.tgz",
-            "integrity": "sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.17.tgz",
+            "integrity": "sha512-QM50vJ/y+8I60qEmFxMoxIx4de03pGo2HwxdBeFd4nMh364X6TIBZ6VQ5UQmPbQWUVWHWws5MmJXlHAXvJEmpQ==",
             "cpu": [
                 "x64"
             ],
@@ -277,9 +278,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.18.tgz",
-            "integrity": "sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.17.tgz",
+            "integrity": "sha512-/jGlhWR7Sj9JPZHzXyyMZ1RFMkNPjC6QIAan0sDOtIo2TYk3tZn5UDrkE0XgsTQCxWTTOcMPf9p6Rh2hXtl5TQ==",
             "cpu": [
                 "x64"
             ],
@@ -293,9 +294,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.18.tgz",
-            "integrity": "sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.17.tgz",
+            "integrity": "sha512-rSEeYaGgyGGf4qZM2NonMhMOP/5EHp4u9ehFiBrg7stH6BYEEjlkVREuDEcQ0LfIl53OXLxNbfuIj7mr5m29TA==",
             "cpu": [
                 "x64"
             ],
@@ -309,9 +310,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.18.tgz",
-            "integrity": "sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.17.tgz",
+            "integrity": "sha512-Y7ZBbkLqlSgn4+zot4KUNYst0bFoO68tRgI6mY2FIM+b7ZbyNVtNbDP5y8qlu4/knZZ73fgJDlXID+ohY5zt5g==",
             "cpu": [
                 "x64"
             ],
@@ -325,9 +326,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.18.tgz",
-            "integrity": "sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.17.tgz",
+            "integrity": "sha512-bwPmTJsEQcbZk26oYpc4c/8PvTY3J5/QK8jM19DVlEsAB41M39aWovWoHtNm78sd6ip6prilxeHosPADXtEJFw==",
             "cpu": [
                 "arm64"
             ],
@@ -341,9 +342,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.18.tgz",
-            "integrity": "sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.17.tgz",
+            "integrity": "sha512-H/XaPtPKli2MhW+3CQueo6Ni3Avggi6hP/YvgkEe1aSaxw+AeO8MFjq8DlgfTd9Iz4Yih3QCZI6YLMoyccnPRg==",
             "cpu": [
                 "ia32"
             ],
@@ -357,9 +358,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.18.tgz",
-            "integrity": "sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.17.tgz",
+            "integrity": "sha512-fGEb8f2BSA3CW7riJVurug65ACLuQAzKq0SSqkY2b2yHHH0MzDfbLyKIGzHwOI/gkHcxM/leuSW6D5w/LMNitA==",
             "cpu": [
                 "x64"
             ],
@@ -619,6 +620,12 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/elkjs": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
+            "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==",
+            "dev": true
+        },
         "node_modules/end-of-stream": {
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -629,9 +636,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.18.tgz",
-            "integrity": "sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.17.tgz",
+            "integrity": "sha512-1GJtYnUxsJreHYA0Y+iQz2UEykonY66HNWOb0yXYZi9/kNrORUEHVg87eQsCtqh59PEJ5YVZJO98JHznMJSWjg==",
             "dev": true,
             "hasInstallScript": true,
             "bin": {
@@ -641,28 +648,28 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "@esbuild/android-arm": "0.17.18",
-                "@esbuild/android-arm64": "0.17.18",
-                "@esbuild/android-x64": "0.17.18",
-                "@esbuild/darwin-arm64": "0.17.18",
-                "@esbuild/darwin-x64": "0.17.18",
-                "@esbuild/freebsd-arm64": "0.17.18",
-                "@esbuild/freebsd-x64": "0.17.18",
-                "@esbuild/linux-arm": "0.17.18",
-                "@esbuild/linux-arm64": "0.17.18",
-                "@esbuild/linux-ia32": "0.17.18",
-                "@esbuild/linux-loong64": "0.17.18",
-                "@esbuild/linux-mips64el": "0.17.18",
-                "@esbuild/linux-ppc64": "0.17.18",
-                "@esbuild/linux-riscv64": "0.17.18",
-                "@esbuild/linux-s390x": "0.17.18",
-                "@esbuild/linux-x64": "0.17.18",
-                "@esbuild/netbsd-x64": "0.17.18",
-                "@esbuild/openbsd-x64": "0.17.18",
-                "@esbuild/sunos-x64": "0.17.18",
-                "@esbuild/win32-arm64": "0.17.18",
-                "@esbuild/win32-ia32": "0.17.18",
-                "@esbuild/win32-x64": "0.17.18"
+                "@esbuild/android-arm": "0.18.17",
+                "@esbuild/android-arm64": "0.18.17",
+                "@esbuild/android-x64": "0.18.17",
+                "@esbuild/darwin-arm64": "0.18.17",
+                "@esbuild/darwin-x64": "0.18.17",
+                "@esbuild/freebsd-arm64": "0.18.17",
+                "@esbuild/freebsd-x64": "0.18.17",
+                "@esbuild/linux-arm": "0.18.17",
+                "@esbuild/linux-arm64": "0.18.17",
+                "@esbuild/linux-ia32": "0.18.17",
+                "@esbuild/linux-loong64": "0.18.17",
+                "@esbuild/linux-mips64el": "0.18.17",
+                "@esbuild/linux-ppc64": "0.18.17",
+                "@esbuild/linux-riscv64": "0.18.17",
+                "@esbuild/linux-s390x": "0.18.17",
+                "@esbuild/linux-x64": "0.18.17",
+                "@esbuild/netbsd-x64": "0.18.17",
+                "@esbuild/openbsd-x64": "0.18.17",
+                "@esbuild/sunos-x64": "0.18.17",
+                "@esbuild/win32-arm64": "0.18.17",
+                "@esbuild/win32-ia32": "0.18.17",
+                "@esbuild/win32-x64": "0.18.17"
             }
         },
         "node_modules/execa": {
@@ -981,9 +988,9 @@
             "dev": true
         },
         "node_modules/postcss": {
-            "version": "8.4.23",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
-            "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
+            "version": "8.4.27",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
+            "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
             "dev": true,
             "funding": [
                 {
@@ -1063,9 +1070,9 @@
             "dev": true
         },
         "node_modules/rollup": {
-            "version": "3.21.5",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.5.tgz",
-            "integrity": "sha512-a4NTKS4u9PusbUJcfF4IMxuqjFzjm6ifj76P54a7cKnvVzJaG12BLVR+hgU2YDGHzyMMQNxLAZWuALsn8q2oQg==",
+            "version": "3.27.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.27.1.tgz",
+            "integrity": "sha512-tXNDFwOkN6C2w5Blj1g6ForKeFw6c1mDu5jxoeDO3/pmYjgt+8yvIFjKzH5FQUq70OKZBkOt0zzv0THXL7vwzQ==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -1160,6 +1167,19 @@
                 "tinyqueue": "^2.0.3"
             }
         },
+        "node_modules/sprotty-elk": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/sprotty-elk/-/sprotty-elk-0.13.1.tgz",
+            "integrity": "sha512-k3C9BWI5Nc7btbgtqX8Ab2pPBTLUTV6bglvpUANieFGNWQpfGInfTp7RCzA3143lsLxyoApoN/CvyozSm3+qaw==",
+            "dev": true,
+            "dependencies": {
+                "elkjs": "^0.8.2",
+                "sprotty-protocol": "^0.13.0"
+            },
+            "optionalDependencies": {
+                "inversify": "^5.1.1"
+            }
+        },
         "node_modules/sprotty-protocol": {
             "version": "0.13.0",
             "resolved": "https://registry.npmjs.org/sprotty-protocol/-/sprotty-protocol-0.13.0.tgz",
@@ -1215,14 +1235,14 @@
             }
         },
         "node_modules/vite": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.5.tgz",
-            "integrity": "sha512-0gEnL9wiRFxgz40o/i/eTBwm+NEbpUeTWhzKrZDSdKm6nplj+z4lKz8ANDgildxHm47Vg8EUia0aicKbawUVVA==",
+            "version": "4.4.8",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.8.tgz",
+            "integrity": "sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==",
             "dev": true,
             "dependencies": {
-                "esbuild": "^0.17.5",
-                "postcss": "^8.4.23",
-                "rollup": "^3.21.0"
+                "esbuild": "^0.18.10",
+                "postcss": "^8.4.26",
+                "rollup": "^3.25.2"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -1230,12 +1250,16 @@
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
             },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
             },
             "peerDependencies": {
                 "@types/node": ">= 14",
                 "less": "*",
+                "lightningcss": "^1.21.0",
                 "sass": "*",
                 "stylus": "*",
                 "sugarss": "*",
@@ -1246,6 +1270,9 @@
                     "optional": true
                 },
                 "less": {
+                    "optional": true
+                },
+                "lightningcss": {
                     "optional": true
                 },
                 "sass": {
@@ -1286,156 +1313,156 @@
     },
     "dependencies": {
         "@esbuild/android-arm": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.18.tgz",
-            "integrity": "sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.17.tgz",
+            "integrity": "sha512-wHsmJG/dnL3OkpAcwbgoBTTMHVi4Uyou3F5mf58ZtmUyIKfcdA7TROav/6tCzET4A3QW2Q2FC+eFneMU+iyOxg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/android-arm64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.18.tgz",
-            "integrity": "sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.17.tgz",
+            "integrity": "sha512-9np+YYdNDed5+Jgr1TdWBsozZ85U1Oa3xW0c7TWqH0y2aGghXtZsuT8nYRbzOMcl0bXZXjOGbksoTtVOlWrRZg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/android-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.18.tgz",
-            "integrity": "sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.17.tgz",
+            "integrity": "sha512-O+FeWB/+xya0aLg23hHEM2E3hbfwZzjqumKMSIqcHbNvDa+dza2D0yLuymRBQQnC34CWrsJUXyH2MG5VnLd6uw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/darwin-arm64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.18.tgz",
-            "integrity": "sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.17.tgz",
+            "integrity": "sha512-M9uJ9VSB1oli2BE/dJs3zVr9kcCBBsE883prage1NWz6pBS++1oNn/7soPNS3+1DGj0FrkSvnED4Bmlu1VAE9g==",
             "dev": true,
             "optional": true
         },
         "@esbuild/darwin-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.18.tgz",
-            "integrity": "sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.17.tgz",
+            "integrity": "sha512-XDre+J5YeIJDMfp3n0279DFNrGCXlxOuGsWIkRb1NThMZ0BsrWXoTg23Jer7fEXQ9Ye5QjrvXpxnhzl3bHtk0g==",
             "dev": true,
             "optional": true
         },
         "@esbuild/freebsd-arm64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.18.tgz",
-            "integrity": "sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.17.tgz",
+            "integrity": "sha512-cjTzGa3QlNfERa0+ptykyxs5A6FEUQQF0MuilYXYBGdBxD3vxJcKnzDlhDCa1VAJCmAxed6mYhA2KaJIbtiNuQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/freebsd-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.18.tgz",
-            "integrity": "sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.17.tgz",
+            "integrity": "sha512-sOxEvR8d7V7Kw8QqzxWc7bFfnWnGdaFBut1dRUYtu+EIRXefBc/eIsiUiShnW0hM3FmQ5Zf27suDuHsKgZ5QrA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-arm": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.18.tgz",
-            "integrity": "sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.17.tgz",
+            "integrity": "sha512-2d3Lw6wkwgSLC2fIvXKoMNGVaeY8qdN0IC3rfuVxJp89CRfA3e3VqWifGDfuakPmp90+ZirmTfye1n4ncjv2lg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-arm64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.18.tgz",
-            "integrity": "sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.17.tgz",
+            "integrity": "sha512-c9w3tE7qA3CYWjT+M3BMbwMt+0JYOp3vCMKgVBrCl1nwjAlOMYzEo+gG7QaZ9AtqZFj5MbUc885wuBBmu6aADQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-ia32": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.18.tgz",
-            "integrity": "sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.17.tgz",
+            "integrity": "sha512-1DS9F966pn5pPnqXYz16dQqWIB0dmDfAQZd6jSSpiT9eX1NzKh07J6VKR3AoXXXEk6CqZMojiVDSZi1SlmKVdg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-loong64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.18.tgz",
-            "integrity": "sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.17.tgz",
+            "integrity": "sha512-EvLsxCk6ZF0fpCB6w6eOI2Fc8KW5N6sHlIovNe8uOFObL2O+Mr0bflPHyHwLT6rwMg9r77WOAWb2FqCQrVnwFg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-mips64el": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.18.tgz",
-            "integrity": "sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.17.tgz",
+            "integrity": "sha512-e0bIdHA5p6l+lwqTE36NAW5hHtw2tNRmHlGBygZC14QObsA3bD4C6sXLJjvnDIjSKhW1/0S3eDy+QmX/uZWEYQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-ppc64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.18.tgz",
-            "integrity": "sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.17.tgz",
+            "integrity": "sha512-BAAilJ0M5O2uMxHYGjFKn4nJKF6fNCdP1E0o5t5fvMYYzeIqy2JdAP88Az5LHt9qBoUa4tDaRpfWt21ep5/WqQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-riscv64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.18.tgz",
-            "integrity": "sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.17.tgz",
+            "integrity": "sha512-Wh/HW2MPnC3b8BqRSIme/9Zhab36PPH+3zam5pqGRH4pE+4xTrVLx2+XdGp6fVS3L2x+DrsIcsbMleex8fbE6g==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-s390x": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.18.tgz",
-            "integrity": "sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.17.tgz",
+            "integrity": "sha512-j/34jAl3ul3PNcK3pfI0NSlBANduT2UO5kZ7FCaK33XFv3chDhICLY8wJJWIhiQ+YNdQ9dxqQctRg2bvrMlYgg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.18.tgz",
-            "integrity": "sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.17.tgz",
+            "integrity": "sha512-QM50vJ/y+8I60qEmFxMoxIx4de03pGo2HwxdBeFd4nMh364X6TIBZ6VQ5UQmPbQWUVWHWws5MmJXlHAXvJEmpQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/netbsd-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.18.tgz",
-            "integrity": "sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.17.tgz",
+            "integrity": "sha512-/jGlhWR7Sj9JPZHzXyyMZ1RFMkNPjC6QIAan0sDOtIo2TYk3tZn5UDrkE0XgsTQCxWTTOcMPf9p6Rh2hXtl5TQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/openbsd-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.18.tgz",
-            "integrity": "sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.17.tgz",
+            "integrity": "sha512-rSEeYaGgyGGf4qZM2NonMhMOP/5EHp4u9ehFiBrg7stH6BYEEjlkVREuDEcQ0LfIl53OXLxNbfuIj7mr5m29TA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/sunos-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.18.tgz",
-            "integrity": "sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.17.tgz",
+            "integrity": "sha512-Y7ZBbkLqlSgn4+zot4KUNYst0bFoO68tRgI6mY2FIM+b7ZbyNVtNbDP5y8qlu4/knZZ73fgJDlXID+ohY5zt5g==",
             "dev": true,
             "optional": true
         },
         "@esbuild/win32-arm64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.18.tgz",
-            "integrity": "sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.17.tgz",
+            "integrity": "sha512-bwPmTJsEQcbZk26oYpc4c/8PvTY3J5/QK8jM19DVlEsAB41M39aWovWoHtNm78sd6ip6prilxeHosPADXtEJFw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/win32-ia32": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.18.tgz",
-            "integrity": "sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.17.tgz",
+            "integrity": "sha512-H/XaPtPKli2MhW+3CQueo6Ni3Avggi6hP/YvgkEe1aSaxw+AeO8MFjq8DlgfTd9Iz4Yih3QCZI6YLMoyccnPRg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/win32-x64": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.18.tgz",
-            "integrity": "sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.17.tgz",
+            "integrity": "sha512-fGEb8f2BSA3CW7riJVurug65ACLuQAzKq0SSqkY2b2yHHH0MzDfbLyKIGzHwOI/gkHcxM/leuSW6D5w/LMNitA==",
             "dev": true,
             "optional": true
         },
@@ -1646,6 +1673,12 @@
                 "which": "^2.0.1"
             }
         },
+        "elkjs": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
+            "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==",
+            "dev": true
+        },
         "end-of-stream": {
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -1656,33 +1689,33 @@
             }
         },
         "esbuild": {
-            "version": "0.17.18",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.18.tgz",
-            "integrity": "sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==",
+            "version": "0.18.17",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.17.tgz",
+            "integrity": "sha512-1GJtYnUxsJreHYA0Y+iQz2UEykonY66HNWOb0yXYZi9/kNrORUEHVg87eQsCtqh59PEJ5YVZJO98JHznMJSWjg==",
             "dev": true,
             "requires": {
-                "@esbuild/android-arm": "0.17.18",
-                "@esbuild/android-arm64": "0.17.18",
-                "@esbuild/android-x64": "0.17.18",
-                "@esbuild/darwin-arm64": "0.17.18",
-                "@esbuild/darwin-x64": "0.17.18",
-                "@esbuild/freebsd-arm64": "0.17.18",
-                "@esbuild/freebsd-x64": "0.17.18",
-                "@esbuild/linux-arm": "0.17.18",
-                "@esbuild/linux-arm64": "0.17.18",
-                "@esbuild/linux-ia32": "0.17.18",
-                "@esbuild/linux-loong64": "0.17.18",
-                "@esbuild/linux-mips64el": "0.17.18",
-                "@esbuild/linux-ppc64": "0.17.18",
-                "@esbuild/linux-riscv64": "0.17.18",
-                "@esbuild/linux-s390x": "0.17.18",
-                "@esbuild/linux-x64": "0.17.18",
-                "@esbuild/netbsd-x64": "0.17.18",
-                "@esbuild/openbsd-x64": "0.17.18",
-                "@esbuild/sunos-x64": "0.17.18",
-                "@esbuild/win32-arm64": "0.17.18",
-                "@esbuild/win32-ia32": "0.17.18",
-                "@esbuild/win32-x64": "0.17.18"
+                "@esbuild/android-arm": "0.18.17",
+                "@esbuild/android-arm64": "0.18.17",
+                "@esbuild/android-x64": "0.18.17",
+                "@esbuild/darwin-arm64": "0.18.17",
+                "@esbuild/darwin-x64": "0.18.17",
+                "@esbuild/freebsd-arm64": "0.18.17",
+                "@esbuild/freebsd-x64": "0.18.17",
+                "@esbuild/linux-arm": "0.18.17",
+                "@esbuild/linux-arm64": "0.18.17",
+                "@esbuild/linux-ia32": "0.18.17",
+                "@esbuild/linux-loong64": "0.18.17",
+                "@esbuild/linux-mips64el": "0.18.17",
+                "@esbuild/linux-ppc64": "0.18.17",
+                "@esbuild/linux-riscv64": "0.18.17",
+                "@esbuild/linux-s390x": "0.18.17",
+                "@esbuild/linux-x64": "0.18.17",
+                "@esbuild/netbsd-x64": "0.18.17",
+                "@esbuild/openbsd-x64": "0.18.17",
+                "@esbuild/sunos-x64": "0.18.17",
+                "@esbuild/win32-arm64": "0.18.17",
+                "@esbuild/win32-ia32": "0.18.17",
+                "@esbuild/win32-x64": "0.18.17"
             }
         },
         "execa": {
@@ -1901,9 +1934,9 @@
             "dev": true
         },
         "postcss": {
-            "version": "8.4.23",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
-            "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
+            "version": "8.4.27",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
+            "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
             "dev": true,
             "requires": {
                 "nanoid": "^3.3.6",
@@ -1948,9 +1981,9 @@
             "dev": true
         },
         "rollup": {
-            "version": "3.21.5",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.5.tgz",
-            "integrity": "sha512-a4NTKS4u9PusbUJcfF4IMxuqjFzjm6ifj76P54a7cKnvVzJaG12BLVR+hgU2YDGHzyMMQNxLAZWuALsn8q2oQg==",
+            "version": "3.27.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.27.1.tgz",
+            "integrity": "sha512-tXNDFwOkN6C2w5Blj1g6ForKeFw6c1mDu5jxoeDO3/pmYjgt+8yvIFjKzH5FQUq70OKZBkOt0zzv0THXL7vwzQ==",
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
@@ -2023,6 +2056,17 @@
                 "tinyqueue": "^2.0.3"
             }
         },
+        "sprotty-elk": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/sprotty-elk/-/sprotty-elk-0.13.1.tgz",
+            "integrity": "sha512-k3C9BWI5Nc7btbgtqX8Ab2pPBTLUTV6bglvpUANieFGNWQpfGInfTp7RCzA3143lsLxyoApoN/CvyozSm3+qaw==",
+            "dev": true,
+            "requires": {
+                "elkjs": "^0.8.2",
+                "inversify": "^5.1.1",
+                "sprotty-protocol": "^0.13.0"
+            }
+        },
         "sprotty-protocol": {
             "version": "0.13.0",
             "resolved": "https://registry.npmjs.org/sprotty-protocol/-/sprotty-protocol-0.13.0.tgz",
@@ -2062,15 +2106,15 @@
             "dev": true
         },
         "vite": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.5.tgz",
-            "integrity": "sha512-0gEnL9wiRFxgz40o/i/eTBwm+NEbpUeTWhzKrZDSdKm6nplj+z4lKz8ANDgildxHm47Vg8EUia0aicKbawUVVA==",
+            "version": "4.4.8",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.8.tgz",
+            "integrity": "sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==",
             "dev": true,
             "requires": {
-                "esbuild": "^0.17.5",
+                "esbuild": "^0.18.10",
                 "fsevents": "~2.3.2",
-                "postcss": "^8.4.23",
-                "rollup": "^3.21.0"
+                "postcss": "^8.4.26",
+                "rollup": "^3.25.2"
             }
         },
         "which": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "pretty-quick": "^3.1.3",
         "reflect-metadata": "^0.1.13",
         "sprotty": "^0.13.0",
+        "sprotty-elk": "^0.13.1",
         "sprotty-protocol": "^0.13.0",
         "typescript": "^5.0.2",
         "vite": "^4.3.2"

--- a/src/common/commandPalette.ts
+++ b/src/common/commandPalette.ts
@@ -13,7 +13,7 @@ import { LoadDiagramAction } from "../features/serialize/load";
 import { FIT_TO_SCREEN_PADDING } from "../utils";
 import { SaveDiagramAction } from "../features/serialize/save";
 import { LoadDefaultDiagramAction } from "../features/serialize/loadDefaultDiagram";
-import { LayoutModelAction } from "../features/autoLayout/di.config";
+import { LayoutModelAction } from "../features/autoLayout/command";
 
 import "@vscode/codicons/dist/codicon.css";
 import "sprotty/css/command-palette.css";

--- a/src/common/commandPalette.ts
+++ b/src/common/commandPalette.ts
@@ -13,6 +13,7 @@ import { LoadDiagramAction } from "../features/serialize/load";
 import { FIT_TO_SCREEN_PADDING } from "../utils";
 import { SaveDiagramAction } from "../features/serialize/save";
 import { LoadDefaultDiagramAction } from "../features/serialize/loadDefaultDiagram";
+import { LayoutModelAction } from "../features/autoLayout/di.config";
 
 import "@vscode/codicons/dist/codicon.css";
 import "sprotty/css/command-palette.css";
@@ -42,6 +43,11 @@ export class ServerCommandPaletteActionProvider implements ICommandPaletteAction
             new LabeledAction("Load diagram from JSON", [LoadDiagramAction.create(), commitAction], "go-to-file"),
             new LabeledAction("Export as SVG", [RequestExportSvgAction.create()], "export"),
             new LabeledAction("Load default diagram", [LoadDefaultDiagramAction.create(), commitAction], "clear-all"),
+            new LabeledAction(
+                "Layout diagram",
+                [LayoutModelAction.create(), commitAction, fitToScreenAction],
+                "layout",
+            ),
         ];
     }
 }

--- a/src/features/autoLayout/command.ts
+++ b/src/features/autoLayout/command.ts
@@ -1,0 +1,48 @@
+import { inject } from "inversify";
+import { Command, CommandExecutionContext, LocalModelSource, SModelRoot, TYPES } from "sprotty";
+import { Action, IModelLayoutEngine, SGraph } from "sprotty-protocol";
+
+export interface LayoutModelAction extends Action {
+    kind: typeof LayoutModelAction.KIND;
+}
+export namespace LayoutModelAction {
+    export const KIND = "layoutModel";
+
+    export function create(): LayoutModelAction {
+        return {
+            kind: KIND,
+        };
+    }
+}
+
+export class LayoutModelCommand extends Command {
+    static readonly KIND = LayoutModelAction.KIND;
+
+    @inject(TYPES.IModelLayoutEngine)
+    protected readonly layoutEngine?: IModelLayoutEngine;
+
+    @inject(TYPES.ModelSource)
+    protected readonly modelSource?: LocalModelSource;
+
+    async execute(context: CommandExecutionContext): Promise<SModelRoot> {
+        if (!this.layoutEngine || !this.modelSource) throw new Error("Missing injects");
+
+        // Layouting is normally done on the graph schema.
+        // This is not viable for us because the dfd nodes have a dynamically computed size.
+        // This is only available on loaded classes of the elements, not the json schema.
+        // Thankfully the node implementation classes have all needed properties as well.
+        // So we can just force cast the graph from the loaded version into the "json graph schema".
+        // Using of the "bounds" property that the implementation classes have is done using DfdElkLayoutEngine.
+        const newModel = await this.layoutEngine.layout(context.root as unknown as SGraph);
+        // Here we need to cast back.
+        return newModel as unknown as SModelRoot;
+    }
+
+    undo(context: CommandExecutionContext): SModelRoot {
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): Promise<SModelRoot> {
+        return this.execute(context);
+    }
+}

--- a/src/features/autoLayout/di.config.ts
+++ b/src/features/autoLayout/di.config.ts
@@ -1,119 +1,15 @@
-import { ContainerModule, inject, injectable } from "inversify";
-import {
-    Command,
-    CommandExecutionContext,
-    LocalModelSource,
-    TYPES,
-    configureCommand,
-    SShapeElement,
-    SModelRoot,
-} from "sprotty";
-import {
-    DefaultLayoutConfigurator,
-    ElkFactory,
-    ElkLayoutEngine,
-    IElementFilter,
-    ILayoutConfigurator,
-} from "sprotty-elk";
-import {
-    Action,
-    IModelLayoutEngine,
-    SGraph,
-    SModelIndex,
-    SShapeElement as SShapeElementSchema,
-} from "sprotty-protocol";
-import { LayoutOptions, ElkShape } from "elkjs";
-import ElkConstructor from "elkjs/lib/elk.bundled";
-import { constructorInject } from "../../utils";
-
-class DfdLayoutConfigurator extends DefaultLayoutConfigurator {
-    protected override graphOptions(_sgraph: SGraph, _index: SModelIndex): LayoutOptions {
-        return {
-            "org.eclipse.elk.algorithm": "org.eclipse.elk.layered",
-            "org.eclipse.elk.spacing.nodeNode": "45.0",
-            "org.eclipse.elk.spacing.edgeLabel": "10.0",
-            "org.eclipse.elk.edgeLabels.inline": "false",
-            "org.eclipse.elk.layered.spacing.edgeNodeBetweenLayers": "30.0",
-            "org.eclipse.elk.omitNodeMicroLayout": "true",
-            "org.eclipse.elk.force.temperature": "0.0002",
-            "org.eclipse.elk.stress.desiredEdgeLength": "200",
-            "org.eclipse.elk.nodeSize.minimum": "new KVector(40, 40)",
-        };
-    }
-}
-
-const elkFactory = () =>
-    new ElkConstructor({
-        algorithms: ["layered", "force", "stress"],
-    });
-
-@injectable()
-class CustomElkLayoutEngine extends ElkLayoutEngine {
-    constructor(
-        @constructorInject(ElkFactory) elkFactory: ElkFactory,
-        @constructorInject(IElementFilter) elementFilter: IElementFilter,
-        @constructorInject(ILayoutConfigurator) configurator: ILayoutConfigurator,
-    ) {
-        super(elkFactory, elementFilter, configurator);
-    }
-
-    protected override transformShape(elkShape: ElkShape, sshape: SShapeElement | SShapeElementSchema): void {
-        if (sshape.position) {
-            elkShape.x = sshape.position.x;
-            elkShape.y = sshape.position.y;
-        }
-        if ("bounds" in sshape) {
-            elkShape.width = sshape.bounds.width ?? sshape.size.width;
-            elkShape.height = sshape.bounds.height ?? sshape.size.height;
-        }
-    }
-}
-
-export interface LayoutModelAction extends Action {
-    kind: typeof LayoutModelAction.KIND;
-}
-export namespace LayoutModelAction {
-    export const KIND = "layoutModel";
-
-    export function create(): LayoutModelAction {
-        return {
-            kind: KIND,
-        };
-    }
-}
-
-class LayoutModelCommand extends Command {
-    static readonly KIND = LayoutModelAction.KIND;
-
-    @inject(TYPES.IModelLayoutEngine)
-    protected readonly layoutEngine?: IModelLayoutEngine;
-
-    @inject(TYPES.ModelSource)
-    protected readonly modelSource?: LocalModelSource;
-
-    async execute(context: CommandExecutionContext): Promise<SModelRoot> {
-        if (!this.layoutEngine || !this.modelSource) throw new Error("Missing injects");
-
-        const newModel = this.layoutEngine.layout(context.root as unknown as SGraph);
-        return (await newModel) as unknown as SModelRoot;
-    }
-
-    undo(context: CommandExecutionContext): SModelRoot {
-        return context.root;
-    }
-
-    redo(context: CommandExecutionContext): Promise<SModelRoot> {
-        return this.execute(context);
-    }
-}
+import { ContainerModule } from "inversify";
+import { TYPES, configureCommand } from "sprotty";
+import { ElkFactory, ILayoutConfigurator } from "sprotty-elk";
+import { LayoutModelCommand } from "./command";
+import { DfdElkLayoutEngine, DfdLayoutConfigurator, elkFactory } from "./layouter";
 
 export const dfdAutoLayoutModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-    bind(CustomElkLayoutEngine).toSelf().inSingletonScope();
-    bind(TYPES.IModelLayoutEngine).toService(CustomElkLayoutEngine);
+    bind(DfdElkLayoutEngine).toSelf().inSingletonScope();
+    bind(TYPES.IModelLayoutEngine).toService(DfdElkLayoutEngine);
     rebind(ILayoutConfigurator).to(DfdLayoutConfigurator);
     bind(ElkFactory).toConstantValue(elkFactory);
 
     const context = { bind, unbind, isBound, rebind };
-
     configureCommand(context, LayoutModelCommand);
 });

--- a/src/features/autoLayout/di.config.ts
+++ b/src/features/autoLayout/di.config.ts
@@ -1,0 +1,114 @@
+import { ContainerModule, inject, injectable } from "inversify";
+import {
+    Command,
+    CommandExecutionContext,
+    LocalModelSource,
+    TYPES,
+    configureCommand,
+    SShapeElement,
+    SModelRoot,
+} from "sprotty";
+import {
+    DefaultLayoutConfigurator,
+    ElkFactory,
+    ElkLayoutEngine,
+    IElementFilter,
+    ILayoutConfigurator,
+} from "sprotty-elk";
+import {
+    Action,
+    IModelLayoutEngine,
+    SGraph,
+    SModelIndex,
+    SShapeElement as SShapeElementSchema,
+} from "sprotty-protocol";
+import { LayoutOptions, ElkShape } from "elkjs";
+import ElkConstructor from "elkjs/lib/elk.bundled";
+import { constructorInject } from "../../utils";
+
+class DfdLayoutConfigurator extends DefaultLayoutConfigurator {
+    protected override graphOptions(_sgraph: SGraph, _index: SModelIndex): LayoutOptions {
+        return {
+            "org.eclipse.elk.algorithm": "org.eclipse.elk.layered",
+            "org.eclipse.elk.direction": "DOWN",
+            "org.eclipse.elk.spacing.nodeNode": "30.0",
+            "org.eclipse.elk.layered.spacing.edgeNodeBetweenLayers": "30.0",
+        };
+    }
+}
+
+const elkFactory = () =>
+    new ElkConstructor({
+        algorithms: ["layered"],
+    });
+
+@injectable()
+class CustomElkLayoutEngine extends ElkLayoutEngine {
+    constructor(
+        @constructorInject(ElkFactory) elkFactory: ElkFactory,
+        @constructorInject(IElementFilter) elementFilter: IElementFilter,
+        @constructorInject(ILayoutConfigurator) configurator: ILayoutConfigurator,
+    ) {
+        super(elkFactory, elementFilter, configurator);
+    }
+
+    protected override transformShape(elkShape: ElkShape, sshape: SShapeElement | SShapeElementSchema): void {
+        if (sshape.position) {
+            elkShape.x = sshape.position.x;
+            elkShape.y = sshape.position.y;
+        }
+        if ("bounds" in sshape) {
+            elkShape.width = sshape.bounds.width;
+            elkShape.height = sshape.bounds.height;
+        }
+    }
+}
+
+export interface LayoutModelAction extends Action {
+    kind: typeof LayoutModelAction.KIND;
+}
+export namespace LayoutModelAction {
+    export const KIND = "layoutModel";
+
+    export function create(): LayoutModelAction {
+        return {
+            kind: KIND,
+        };
+    }
+}
+
+class LayoutModelCommand extends Command {
+    static readonly KIND = LayoutModelAction.KIND;
+
+    @inject(TYPES.IModelLayoutEngine)
+    protected readonly layoutEngine?: IModelLayoutEngine;
+
+    @inject(TYPES.ModelSource)
+    protected readonly modelSource?: LocalModelSource;
+
+    async execute(context: CommandExecutionContext): Promise<SModelRoot> {
+        if (!this.layoutEngine || !this.modelSource) throw new Error("Missing injects");
+
+        const newModel = this.layoutEngine.layout(context.root as unknown as SGraph);
+        return (await newModel) as unknown as SModelRoot;
+    }
+
+    undo(context: CommandExecutionContext): SModelRoot {
+        return context.root;
+    }
+
+    redo(context: CommandExecutionContext): Promise<SModelRoot> {
+        return this.execute(context);
+    }
+}
+
+export const dfdAutoLayoutModule = new ContainerModule((bind, unbind, isBound, rebind) => {
+    bind(CustomElkLayoutEngine).toSelf().inSingletonScope();
+    bind(TYPES.IModelLayoutEngine).toService(CustomElkLayoutEngine);
+    rebind(ILayoutConfigurator).to(DfdLayoutConfigurator);
+    bind(ElkFactory).toConstantValue(elkFactory);
+
+    const context = { bind, unbind, isBound, rebind };
+
+    configureCommand(context, LayoutModelCommand);
+});

--- a/src/features/autoLayout/di.config.ts
+++ b/src/features/autoLayout/di.config.ts
@@ -29,18 +29,22 @@ import { constructorInject } from "../../utils";
 class DfdLayoutConfigurator extends DefaultLayoutConfigurator {
     protected override graphOptions(_sgraph: SGraph, _index: SModelIndex): LayoutOptions {
         return {
-            "org.eclipse.elk.algorithm": "org.eclipse.elk.stress",
+            "org.eclipse.elk.algorithm": "org.eclipse.elk.layered",
             "org.eclipse.elk.spacing.nodeNode": "45.0",
             "org.eclipse.elk.spacing.edgeLabel": "10.0",
             "org.eclipse.elk.edgeLabels.inline": "false",
             "org.eclipse.elk.layered.spacing.edgeNodeBetweenLayers": "30.0",
+            "org.eclipse.elk.omitNodeMicroLayout": "true",
+            "org.eclipse.elk.force.temperature": "0.0002",
+            "org.eclipse.elk.stress.desiredEdgeLength": "200",
+            "org.eclipse.elk.nodeSize.minimum": "new KVector(40, 40)",
         };
     }
 }
 
 const elkFactory = () =>
     new ElkConstructor({
-        algorithms: ["stress"],
+        algorithms: ["layered", "force", "stress"],
     });
 
 @injectable()

--- a/src/features/autoLayout/di.config.ts
+++ b/src/features/autoLayout/di.config.ts
@@ -29,9 +29,10 @@ import { constructorInject } from "../../utils";
 class DfdLayoutConfigurator extends DefaultLayoutConfigurator {
     protected override graphOptions(_sgraph: SGraph, _index: SModelIndex): LayoutOptions {
         return {
-            "org.eclipse.elk.algorithm": "org.eclipse.elk.layered",
-            "org.eclipse.elk.direction": "DOWN",
-            "org.eclipse.elk.spacing.nodeNode": "30.0",
+            "org.eclipse.elk.algorithm": "org.eclipse.elk.stress",
+            "org.eclipse.elk.spacing.nodeNode": "45.0",
+            "org.eclipse.elk.spacing.edgeLabel": "10.0",
+            "org.eclipse.elk.edgeLabels.inline": "false",
             "org.eclipse.elk.layered.spacing.edgeNodeBetweenLayers": "30.0",
         };
     }
@@ -39,7 +40,7 @@ class DfdLayoutConfigurator extends DefaultLayoutConfigurator {
 
 const elkFactory = () =>
     new ElkConstructor({
-        algorithms: ["layered"],
+        algorithms: ["stress"],
     });
 
 @injectable()
@@ -58,8 +59,8 @@ class CustomElkLayoutEngine extends ElkLayoutEngine {
             elkShape.y = sshape.position.y;
         }
         if ("bounds" in sshape) {
-            elkShape.width = sshape.bounds.width;
-            elkShape.height = sshape.bounds.height;
+            elkShape.width = sshape.bounds.width ?? sshape.size.width;
+            elkShape.height = sshape.bounds.height ?? sshape.size.height;
         }
     }
 }

--- a/src/features/autoLayout/layouter.ts
+++ b/src/features/autoLayout/layouter.ts
@@ -1,0 +1,61 @@
+import ElkConstructor from "elkjs/lib/elk.bundled";
+import { injectable } from "inversify";
+import {
+    DefaultLayoutConfigurator,
+    ElkFactory,
+    ElkLayoutEngine,
+    IElementFilter,
+    ILayoutConfigurator,
+} from "sprotty-elk";
+import { constructorInject } from "../../utils";
+import { SShapeElement } from "sprotty";
+import { SShapeElement as SShapeElementSchema, SGraph, SModelIndex } from "sprotty-protocol";
+import { ElkShape, LayoutOptions } from "elkjs";
+
+export class DfdLayoutConfigurator extends DefaultLayoutConfigurator {
+    protected override graphOptions(_sgraph: SGraph, _index: SModelIndex): LayoutOptions {
+        // Elk settings. See https://eclipse.dev/elk/reference.html for available options.
+        return {
+            "org.eclipse.elk.algorithm": "org.eclipse.elk.layered",
+            "org.eclipse.elk.spacing.nodeNode": "45.0",
+            "org.eclipse.elk.layered.spacing.edgeNodeBetweenLayers": "30.0",
+            // Do not do micro layout for nodes, which includes the node dimensions etc.
+            // These are all automatically determined by our dfd node views
+            "org.eclipse.elk.omitNodeMicroLayout": "true",
+        };
+    }
+}
+
+export const elkFactory = () =>
+    new ElkConstructor({
+        algorithms: ["layered"],
+    });
+
+/**
+ * Layout engine for the DFD editor.
+ * This class inherits the default ElkLayoutEngine but overrides the transformShape method.
+ * This is necessary because the default ElkLayoutEngine uses the size property of the shapes to determine their sizes.
+ * However with dynamically sized shapes, the size property is set to -1, which is undesired.
+ * Instead in this case the size should be determined by the bounds property which is dynamically computed.
+ */
+@injectable()
+export class DfdElkLayoutEngine extends ElkLayoutEngine {
+    constructor(
+        @constructorInject(ElkFactory) elkFactory: ElkFactory,
+        @constructorInject(IElementFilter) elementFilter: IElementFilter,
+        @constructorInject(ILayoutConfigurator) configurator: ILayoutConfigurator,
+    ) {
+        super(elkFactory, elementFilter, configurator);
+    }
+
+    protected override transformShape(elkShape: ElkShape, sshape: SShapeElement | SShapeElementSchema): void {
+        if (sshape.position) {
+            elkShape.x = sshape.position.x;
+            elkShape.y = sshape.position.y;
+        }
+        if ("bounds" in sshape) {
+            elkShape.width = sshape.bounds.width ?? sshape.size.width;
+            elkShape.height = sshape.bounds.height ?? sshape.size.height;
+        }
+    }
+}

--- a/src/features/autoLayout/layouter.ts
+++ b/src/features/autoLayout/layouter.ts
@@ -17,7 +17,7 @@ export class DfdLayoutConfigurator extends DefaultLayoutConfigurator {
         // Elk settings. See https://eclipse.dev/elk/reference.html for available options.
         return {
             "org.eclipse.elk.algorithm": "org.eclipse.elk.layered",
-            "org.eclipse.elk.spacing.nodeNode": "45.0",
+            "org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers": "30.0",
             "org.eclipse.elk.layered.spacing.edgeNodeBetweenLayers": "30.0",
             // Do not do micro layout for nodes, which includes the node dimensions etc.
             // These are all automatically determined by our dfd node views

--- a/src/features/dfdElements/di.config.ts
+++ b/src/features/dfdElements/di.config.ts
@@ -8,9 +8,10 @@ import {
     configureModelElement,
     editLabelFeature,
     withEditLabelFeature,
+    SLabelView,
 } from "sprotty";
 import {
-    DfdLabelView,
+    DfdPositionalLabelView,
     FunctionNode,
     FunctionNodeView,
     IONode,
@@ -31,7 +32,10 @@ export const dfdElementsModule = new ContainerModule((bind, unbind, isBound, reb
     configureModelElement(context, "edge:arrow", ArrowEdge, ArrowEdgeView, {
         enable: [withEditLabelFeature],
     });
-    configureModelElement(context, "label", SLabel, DfdLabelView, {
+    configureModelElement(context, "label", SLabel, SLabelView, {
+        enable: [editLabelFeature],
+    });
+    configureModelElement(context, "label:positional", SLabel, DfdPositionalLabelView, {
         enable: [editLabelFeature],
     });
     configureModelElement(context, "routing-point", SRoutingHandle, SRoutingHandleView);

--- a/src/features/dfdElements/nodes.tsx
+++ b/src/features/dfdElements/nodes.tsx
@@ -36,7 +36,7 @@ class RectangularDFDNode extends DynamicChildrenNode implements WithEditableLabe
     override setChildren(schema: DFDNodeSchema): void {
         schema.children = [
             {
-                type: "label",
+                type: "label:positional",
                 text: schema.text ?? "",
                 id: schema.id + "-label",
             } as SLabelSchema,
@@ -44,13 +44,15 @@ class RectangularDFDNode extends DynamicChildrenNode implements WithEditableLabe
     }
 
     override removeChildren(schema: DFDNodeSchema): void {
-        const label = schema.children?.find((element) => element.type === "label") as SLabelSchema | undefined;
+        const label = schema.children?.find((element) => element.type === "label:positional") as
+            | SLabelSchema
+            | undefined;
         schema.text = label?.text ?? "";
         schema.children = [];
     }
 
     get editableLabel() {
-        const label = this.children.find((element) => element.type === "label");
+        const label = this.children.find((element) => element.type === "label:positional");
         if (label && isEditableLabel(label)) {
             return label;
         }
@@ -101,7 +103,7 @@ export class StorageNodeView implements IView {
                 {context.renderChildren(node, {
                     xPosition: width / 2,
                     yPosition: 20,
-                } as DfdLabelArgs)}
+                } as DfdPositionalLabelArgs)}
                 {this.labelRenderer.renderNodeLabels(node, 25)}
                 <line x1="0" y1={height} x2={width} y2={height} />
             </g>
@@ -148,7 +150,7 @@ export class FunctionNodeView implements IView {
                 {context.renderChildren(node, {
                     xPosition: fullRadius,
                     yPosition: baseRadius + 4,
-                } as DfdLabelArgs)}
+                } as DfdPositionalLabelArgs)}
                 {this.labelRenderer.renderNodeLabels(node, baseRadius + 10)}
             </g>
         );
@@ -189,21 +191,21 @@ export class IONodeView implements IView {
                 {context.renderChildren(node, {
                     xPosition: width / 2,
                     yPosition: 25,
-                } as DfdLabelArgs)}
+                } as DfdPositionalLabelArgs)}
                 {this.labelRenderer.renderNodeLabels(node, 30)}
             </g>
         );
     }
 }
 
-interface DfdLabelArgs extends IViewArgs {
+interface DfdPositionalLabelArgs extends IViewArgs {
     xPosition: number;
     yPosition: number;
 }
 
 @injectable()
-export class DfdLabelView extends ShapeView {
-    private getPosition(label: Readonly<SLabel>, args?: DfdLabelArgs | IViewArgs): Point {
+export class DfdPositionalLabelView extends ShapeView {
+    private getPosition(label: Readonly<SLabel>, args?: DfdPositionalLabelArgs | IViewArgs): Point {
         if (args && "xPosition" in args && "yPosition" in args) {
             return { x: args.xPosition, y: args.yPosition };
         } else {
@@ -214,7 +216,7 @@ export class DfdLabelView extends ShapeView {
         }
     }
 
-    render(label: Readonly<SLabel>, _context: RenderingContext, args?: DfdLabelArgs): VNode | undefined {
+    render(label: Readonly<SLabel>, _context: RenderingContext, args?: DfdPositionalLabelArgs): VNode | undefined {
         const position = this.getPosition(label, args);
 
         return (

--- a/src/features/dfdElements/nodes.tsx
+++ b/src/features/dfdElements/nodes.tsx
@@ -78,7 +78,7 @@ export class StorageNode extends RectangularDFDNode {
         return {
             x: this.position.x,
             y: this.position.y,
-            width: Math.max(calculateTextWidth(this.editableLabel?.text), 40),
+            width: Math.max(calculateTextWidth(this.editableLabel?.text), 50),
             height: this.calculateHeight(),
         };
     }
@@ -171,7 +171,7 @@ export class IONode extends RectangularDFDNode {
         return {
             x: this.position.x,
             y: this.position.y,
-            width: Math.max(calculateTextWidth(this.editableLabel?.text) + 5, 40),
+            width: Math.max(calculateTextWidth(this.editableLabel?.text) + 5, 60),
             height: this.calculateHeight(),
         };
     }

--- a/src/features/dfdElements/nodes.tsx
+++ b/src/features/dfdElements/nodes.tsx
@@ -37,7 +37,7 @@ class RectangularDFDNode extends DynamicChildrenNode implements WithEditableLabe
         schema.children = [
             {
                 type: "label",
-                text: schema.text,
+                text: schema.text ?? "",
                 id: schema.id + "-label",
             } as SLabelSchema,
         ];

--- a/src/features/serialize/loadDefaultDiagram.ts
+++ b/src/features/serialize/loadDefaultDiagram.ts
@@ -15,7 +15,7 @@ import { generateRandomSprottyId } from "../../utils";
 import { DFDNodeSchema } from "../dfdElements/nodes";
 import { LabelType, LabelTypeRegistry } from "../labels/labelTypeRegistry";
 import { DynamicChildrenProcessor } from "../dfdElements/dynamicChildren";
-import { fitToScreenAfterLoad } from "./load";
+import { postLoadActions } from "./load";
 
 const storageId = generateRandomSprottyId();
 const functionId = generateRandomSprottyId();
@@ -125,12 +125,12 @@ export class LoadDefaultDiagramCommand extends Command {
         this.newRoot = context.modelFactory.createRoot(graphCopy);
 
         this.logger.info(this, "Default Model loaded successfully");
-        fitToScreenAfterLoad(this.newRoot, this.actionDispatcher);
 
         this.labelTypeRegistry.clearLabelTypes();
         this.labelTypeRegistry.registerLabelType(locationLabelType);
         this.logger.info(this, "Default Label Types loaded successfully");
 
+        postLoadActions(this.newRoot, this.actionDispatcher);
         return this.newRoot;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,8 @@ import {
     viewportModule,
     zorderModule,
 } from "sprotty";
+import { elkLayoutModule } from "sprotty-elk";
+import { dfdAutoLayoutModule } from "./features/autoLayout/di.config";
 import { dfdCommonModule } from "./common/di.config";
 import { dfdLabelModule } from "./features/labels/di.config";
 import { toolPaletteModule } from "./features/toolPalette/di.config";
@@ -71,9 +73,11 @@ container.load(
     edgeLayoutModule,
     hoverModule,
     commandPaletteModule,
+    elkLayoutModule,
 
     // Custom modules
     dfdCommonModule,
+    dfdAutoLayoutModule,
     dfdElementsModule,
     serializeModule,
     dfdLabelModule,


### PR DESCRIPTION
Adds the initial implementation of auto-layouting.
Currently, layouting must be manually invoked using the command palette.
Works well with small diagrams but medium-sized diagrams and large diagrams don't work well because the text of the edge labels are not taken into account by elk resulting in a lot of text collisions.