### PR TITLE
Add filled background to edge labels to make them more readable

### DIFF
--- a/src/common/helpUi.tsx
+++ b/src/common/helpUi.tsx
@@ -32,7 +32,7 @@ export class HelpUI extends AbstractUIExtension {
                     <p><kbd>Del</kbd>: Delete selected elements</p>
                     <p><kbd>T</kbd>: Toggle Label Type Edit UI</p>
                     <p><kbd>CTRL</kbd>+<kbd>O</kbd>: Load diagram from json</p>
-                    <p><kbd>CTRL</kbd>+<kbd>Alt</kbd><kbd>O</kbd>: Open default diagram</p>
+                    <p><kbd>CTRL</kbd>+<kbd>Alt</kbd>+<kbd>O</kbd>: Open default diagram</p>
                     <p><kbd>CTRL</kbd>+<kbd>S</kbd>: Save diagram to json</p>
                     <p><kbd>CTRL</kbd>+<kbd>L</kbd>: Automatically layout diagram</p>
                 </div>

--- a/src/features/dfdElements/di.config.ts
+++ b/src/features/dfdElements/di.config.ts
@@ -11,7 +11,6 @@ import {
     SRoutingHandleImpl,
 } from "sprotty";
 import {
-    DfdPositionalLabelView,
     FunctionNodeImpl,
     FunctionNodeView,
     IONodeImpl,
@@ -20,6 +19,7 @@ import {
     StorageNodeView,
 } from "./nodes";
 import { ArrowEdgeImpl, ArrowEdgeView } from "./edges";
+import { FilledBackgroundLabelView, DfdPositionalLabelView } from "./labels";
 
 import "./styles.css";
 
@@ -33,6 +33,9 @@ export const dfdElementsModule = new ContainerModule((bind, unbind, isBound, reb
         enable: [withEditLabelFeature],
     });
     configureModelElement(context, "label", SLabelImpl, SLabelView, {
+        enable: [editLabelFeature],
+    });
+    configureModelElement(context, "label:filled-background", SLabelImpl, FilledBackgroundLabelView, {
         enable: [editLabelFeature],
     });
     configureModelElement(context, "label:positional", SLabelImpl, DfdPositionalLabelView, {

--- a/src/features/dfdElements/edges.tsx
+++ b/src/features/dfdElements/edges.tsx
@@ -21,7 +21,7 @@ export class ArrowEdgeImpl extends DynamicChildrenEdge implements WithEditableLa
     setChildren(schema: ArrowEdge): void {
         schema.children = [
             {
-                type: "label",
+                type: "label:filled-background",
                 text: schema.text,
                 id: schema.id + "-label",
                 edgePlacement: {

--- a/src/features/dfdElements/labels.tsx
+++ b/src/features/dfdElements/labels.tsx
@@ -1,0 +1,59 @@
+/** @jsx svg */
+import { IViewArgs, SLabelImpl, SNodeImpl, ShapeView, RenderingContext, svg } from "sprotty";
+import {VNode} from "snabbdom";
+import { injectable } from "inversify";
+import { Point } from "sprotty-protocol";
+import { calculateTextSize } from "../../utils";
+
+export interface DfdPositionalLabelArgs extends IViewArgs {
+    xPosition: number;
+    yPosition: number;
+}
+
+@injectable()
+export class DfdPositionalLabelView extends ShapeView {
+    private getPosition(label: Readonly<SLabelImpl>, args?: DfdPositionalLabelArgs | IViewArgs): Point {
+        if (args && "xPosition" in args && "yPosition" in args) {
+            return { x: args.xPosition, y: args.yPosition };
+        } else {
+            const parentSize = (label.parent as SNodeImpl | undefined)?.bounds;
+            const width = parentSize?.width ?? 0;
+            const height = parentSize?.height ?? 0;
+            return { x: width / 2, y: height / 2 };
+        }
+    }
+
+    render(label: Readonly<SLabelImpl>, _context: RenderingContext, args?: DfdPositionalLabelArgs): VNode | undefined {
+        const position = this.getPosition(label, args);
+
+        return (
+            <text class-sprotty-label={true} x={position.x} y={position.y}>
+                {label.text}
+            </text>
+        );
+    }
+}
+
+/**
+ * A sprotty label view that renders the label text with a filled background behind it.
+ * This is used to make the element behind the label invisible.
+ */
+@injectable()
+export class FilledBackgroundLabelView extends ShapeView {
+    static readonly PADDING = 5;
+
+    render(label: Readonly<SLabelImpl>, context: RenderingContext): VNode | undefined {
+        if (!this.isVisible(label, context) || !label.text) {
+            return undefined;
+        }
+
+        const size = calculateTextSize(label.text);
+        const width = size.width + FilledBackgroundLabelView.PADDING;
+        const height = size.height + FilledBackgroundLabelView.PADDING;
+
+        return <g class-label-background={true}>
+            <rect x={-width / 2} y={-height / 2} width={width} height={height} />
+            <text class-sprotty-label={true}>{label.text}</text>
+        </g>
+    }
+}

--- a/src/features/dfdElements/nodes.tsx
+++ b/src/features/dfdElements/nodes.tsx
@@ -6,18 +6,17 @@ import {
     svg,
     withEditLabelFeature,
     RenderingContext,
-    SLabelImpl,
     ShapeView,
-    IViewArgs,
 } from "sprotty";
-import { SNode, SLabel, Bounds, Point } from "sprotty-protocol";
+import { SNode, SLabel, Bounds } from "sprotty-protocol";
 import { inject, injectable } from "inversify";
 import { VNode } from "snabbdom";
 import { LabelAssignment } from "../labels/labelTypeRegistry";
 import { DynamicChildrenNode } from "./dynamicChildren";
 import { containsDfdLabelFeature } from "../labels/elementFeature";
-import { calculateTextWidth } from "../../utils";
+import { calculateTextSize } from "../../utils";
 import { DfdNodeLabelRenderer } from "../labels/labelRenderer";
+import { DfdPositionalLabelArgs } from "./labels";
 
 export interface DfdNode extends SNode {
     text: string;
@@ -60,7 +59,7 @@ export abstract class DfdNodeImpl extends DynamicChildrenNode implements WithEdi
     }
 
     protected calculateWidth(): number {
-        const textWidth = calculateTextWidth(this.editableLabel?.text);
+        const textWidth = calculateTextSize(this.editableLabel?.text).width;
         const labelWidths = this.labels.map(
             (labelAssignment) => DfdNodeLabelRenderer.computeLabelContent(labelAssignment)[1],
         );
@@ -237,31 +236,4 @@ export class IONodeView extends ShapeView {
     }
 }
 
-interface DfdPositionalLabelArgs extends IViewArgs {
-    xPosition: number;
-    yPosition: number;
-}
 
-@injectable()
-export class DfdPositionalLabelView extends ShapeView {
-    private getPosition(label: Readonly<SLabelImpl>, args?: DfdPositionalLabelArgs | IViewArgs): Point {
-        if (args && "xPosition" in args && "yPosition" in args) {
-            return { x: args.xPosition, y: args.yPosition };
-        } else {
-            const parentSize = (label.parent as SNodeImpl | undefined)?.bounds;
-            const width = parentSize?.width ?? 0;
-            const height = parentSize?.height ?? 0;
-            return { x: width / 2, y: height / 2 };
-        }
-    }
-
-    render(label: Readonly<SLabelImpl>, _context: RenderingContext, args?: DfdPositionalLabelArgs): VNode | undefined {
-        const position = this.getPosition(label, args);
-
-        return (
-            <text class-sprotty-label={true} x={position.x} y={position.y}>
-                {label.text}
-            </text>
-        );
-    }
-}

--- a/src/features/dfdElements/styles.css
+++ b/src/features/dfdElements/styles.css
@@ -64,6 +64,11 @@
     stroke: none;
 }
 
+.sprotty-edge .label-background rect {
+    fill: var(--color-background);
+    stroke-width: 0;
+}
+
 /* Misc */
 
 text {

--- a/src/features/labels/labelRenderer.tsx
+++ b/src/features/labels/labelRenderer.tsx
@@ -2,7 +2,7 @@
 import { injectable, inject } from "inversify";
 import { VNode } from "snabbdom";
 import { Hoverable, IActionDispatcher, SShapeElementImpl, TYPES, svg } from "sprotty";
-import { calculateTextWidth } from "../../utils";
+import { calculateTextSize } from "../../utils";
 import { LabelAssignment, LabelTypeRegistry, globalLabelTypeRegistry } from "./labelTypeRegistry";
 import { DeleteLabelAssignmentAction } from "./commands";
 import { ContainsDfdLabels } from "./elementFeature";
@@ -31,7 +31,7 @@ export class DfdNodeLabelRenderer {
         }
 
         const text = `${labelType.name}: ${labelTypeValue.text}`;
-        const width = calculateTextWidth(text, "5pt sans-serif") + 8;
+        const width = calculateTextSize(text, "5pt sans-serif").width + 8;
 
         return [text, width];
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,22 +15,26 @@ export function generateRandomSprottyId(): string {
     return Math.random().toString(36).substring(7);
 }
 
-const contextMap = new Map<string, { context: CanvasRenderingContext2D; cache: Map<string, number> }>();
+interface TextSize {
+    width: number;
+    height: number;
+}
+const contextMap = new Map<string, { context: CanvasRenderingContext2D; cache: Map<string, TextSize> }>();
 
 /**
- * Calculates the width of the given text in the given font using a 2d canvas.
+ * Calculates the width and height of the given text in the given font using a 2d canvas.
  * Because this operation requires interacting with the browser including styling etc.
  * this is rather expensive. Therefore the result is cached with the font and text as a cache key
  * The default width for empty text is 20px.
  * Big diagrams with hundereds of text elements (edges, nodes, labels) would not be possible without caching this operation.
  *
- * @param text the text you need the width for
+ * @param text the text you need the size for
  * @param font the font to use, defaults to "11pt sans-serif"
- * @returns the width of the text in pixels. This does not include any padding or margin
+ * @returns the width and height of the text in pixels. This does not include any padding or margin
  */
-export function calculateTextWidth(text: string | undefined, font: string = "11pt sans-serif"): number {
+export function calculateTextSize(text: string | undefined, font: string = "11pt sans-serif"): TextSize {
     if (!text || text.length === 0) {
-        return 20;
+        return { width: 20, height: 20 };
     }
 
     // Get context for the given font or create a new one if it does not exist yet
@@ -43,20 +47,24 @@ export function calculateTextWidth(text: string | undefined, font: string = "11p
         }
 
         context.font = font; // This is slow. Thats why we have one instance per font to avoid redoing this
-        contextObj = { context, cache: new Map<string, number>() };
+        contextObj = { context, cache: new Map() };
         contextMap.set(font, contextObj);
     }
 
     const { context, cache } = contextObj;
 
     // Get text width from cache or compute it
-    const cachedWidth = cache.get(text);
-    if (cachedWidth) {
-        return cachedWidth;
+    const cachedMetrics = cache.get(text);
+    if (cachedMetrics) {
+        return cachedMetrics;
     } else {
         const metrics = context.measureText(text);
-        const width = Math.round(metrics.width);
-        cache.set(text, width);
-        return width;
+        const textSize: TextSize = {
+            width: Math.round(metrics.width),
+            height: Math.round(metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent),
+        };
+
+        cache.set(text, textSize);
+        return textSize;
     }
 }


### PR DESCRIPTION
Previously the edge line and the label text were visible simultaneously with the foreground color. Because of this the label text sometimes was not very readable because the edge line would strike through it.
With this change the edge labels have a rectangle with a fill of the background color, overpainting everything under it. This means the line of the edge is not hidden in the position of the edge label.